### PR TITLE
Insert space after period on landing page

### DIFF
--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -366,8 +366,8 @@ SagePreview = rclass
                     </Col>
                     <Col sm=6>
                         <ExampleBox title="The Sky is the Limit" index={3}>
-                            <SiteName /> does not arbitrarily restrict you.
-                            <strong>Upload</strong> your own files, <strong>generate</strong> data and results online,
+                            <SiteName /> does not arbitrarily restrict you. <strong>Upload</strong> your
+                            own files, <strong>generate</strong> data and results online,
                             then download or <strong>publish</strong> your results.
                             Besides Sage Worksheets and Jupyter Notebooks,
                             you can work with a <strong>full Linux terminal</strong> and edit text with multiple cursors.


### PR DESCRIPTION
There is no space between the "restrict you." and "Upload" in the rendered html.  It seems that if there is not an explicit space (not just a newline) between the period and the `<strong>` tag, the space is deleted in the rendered html.  Reformatting the paragraph ensures that the newline falls in normal text, which seems to not have the problem (evidenced by other paragraphs).