### PR TITLE
hub/version: fixing logic when updated version is detected

### DIFF
--- a/src/smc-hub/hub.coffee
+++ b/src/smc-hub/hub.coffee
@@ -82,6 +82,7 @@ REGISTER_INTERVAL_S = 45   # every 45 seconds
 smc_version = {}
 init_smc_version = () ->
     smc_version = require('./hub-version')
+    # winston.debug("init smc_version: #{misc.to_json(smc_version.version)}")
     smc_version.on 'change', (version) ->
         winston.debug("smc_version changed -- sending updates to clients")
         for id, c of clients


### PR DESCRIPTION
that's my take for the version check. before, there was just a "require"-load, and not the -reload version ... which did cancel out the `if not ...` check that was always true.