### PR TITLE
Improvements/file selection

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -399,6 +399,10 @@ NoFiles = rclass
             <Alert style={marginTop: '10px', fontWeight : 'bold'} bsStyle='danger'>
                 Warning: Names cannot begin with /
             </Alert>
+        else if ['.', '..'].indexOf(@props.file_search) > -1
+            <Alert style={marginTop: '10px', fontWeight : 'bold'} bsStyle='danger'>
+                Warning: Cannot create a file named . or ..
+            </Alert>
         # Non-empty search and there is a file divisor ('/')
         else if @props.file_search.length > 0 and last_folder_index > 0
             <Alert style={marginTop: '10px'} bsStyle='info'>

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -25,7 +25,7 @@
 misc = require('smc-util/misc')
 {ActivityDisplay, DeletedProjectWarning, DirectoryInput, Icon, Loading, ProjectState, SAGE_LOGO_COLOR
  SearchInput, TimeAgo, ErrorDisplay, Space, Tip, LoginLink, Footer} = require('./r_misc')
-{FileTypeSelector} = require('./project_new')
+{FileTypeSelector}    = require('./project_new')
 {BillingPageLink}     = require('./billing')
 {human_readable_size} = require('./misc_page')
 {MiniTerminal}        = require('./project_miniterm')
@@ -143,8 +143,8 @@ FileRow = rclass
         @props.bordered != next.border
 
     render_icon : ->
-        ext  = misc.filename_extension(@props.name)
-        name = file_associations[ext]?.icon ? 'file'
+        ext   = misc.filename_extension(@props.name)
+        name  = file_associations[ext]?.icon ? 'file'
         style =
             color         : if @props.mask then '#bbbbbb'
             verticalAlign : 'sub'
@@ -344,12 +344,12 @@ DirectoryRow = rclass
 
 NoFiles = rclass
     propTypes :
-        actions     : rtypes.object.isRequired
+        actions       : rtypes.object.isRequired
         create_folder : rtypes.func.isRequired
         create_file   : rtypes.func.isRequired
-        public_view : rtypes.bool
-        file_search : rtypes.string
-        current_path: rtypes.string
+        public_view   : rtypes.bool
+        file_search   : rtypes.string
+        current_path  : rtypes.string
 
     displayName : 'ProjectFiles-NoFiles'
 
@@ -462,18 +462,18 @@ FileListing = rclass
     displayName : 'ProjectFiles-FileListing'
 
     propTypes :
-        listing       : rtypes.array.isRequired
-        file_map      : rtypes.object.isRequired
-        file_search   : rtypes.string
+        listing             : rtypes.array.isRequired
+        file_map            : rtypes.object.isRequired
+        file_search         : rtypes.string
+        checked_files       : rtypes.object
+        current_path        : rtypes.string
+        page_number         : rtypes.number
+        page_size           : rtypes.number
+        public_view         : rtypes.bool
+        actions             : rtypes.object.isRequired
+        create_folder       : rtypes.func.isRequired
+        create_file         : rtypes.func.isRequired
         selected_file_index : rtypes.number
-        checked_files : rtypes.object
-        current_path  : rtypes.string
-        page_number   : rtypes.number
-        page_size     : rtypes.number
-        public_view   : rtypes.bool
-        actions       : rtypes.object.isRequired
-        create_folder : rtypes.func.isRequired
-        create_file   : rtypes.func.isRequired
 
     getDefaultProps : ->
         file_search : ''
@@ -1468,9 +1468,9 @@ ProjectFilesNew = rclass
     displayName : 'ProjectFiles-ProjectFilesNew'
 
     propTypes :
-        file_search  : rtypes.string.isRequired
-        current_path : rtypes.string
-        actions      : rtypes.object.isRequired
+        file_search   : rtypes.string.isRequired
+        current_path  : rtypes.string
+        actions       : rtypes.object.isRequired
         create_folder : rtypes.func.isRequired
         create_file   : rtypes.func.isRequired
 
@@ -1534,15 +1534,15 @@ ProjectFiles = (name) -> rclass
         account :
             other_settings : rtypes.immutable
         "#{name}" :
-            current_path       : rtypes.string
-            activity           : rtypes.object
-            page_number        : rtypes.number
-            file_action        : rtypes.string
-            file_search        : rtypes.string
-            show_hidden        : rtypes.bool
-            sort_by_time       : rtypes.bool
-            error              : rtypes.string
-            checked_files      : rtypes.immutable
+            current_path        : rtypes.string
+            activity            : rtypes.object
+            page_number         : rtypes.number
+            file_action         : rtypes.string
+            file_search         : rtypes.string
+            show_hidden         : rtypes.bool
+            sort_by_time        : rtypes.bool
+            error               : rtypes.string
+            checked_files       : rtypes.immutable
             file_creation_error : rtypes.string
             selected_file_index : rtypes.number
 
@@ -1701,18 +1701,18 @@ ProjectFiles = (name) -> rclass
             </div>
         else if listing?
             <FileListing
-                listing       = {listing}
-                selected_file_index = {@props.selected_file_index}
-                page_size     = {@file_listing_page_size()}
-                page_number   = {@props.page_number}
-                file_map      = {file_map}
-                file_search   = {@props.file_search}
-                checked_files = {@props.checked_files}
-                current_path  = {@props.current_path}
-                public_view   = {public_view}
-                actions       = {@props.actions}
-                create_file   = {@create_file}
-                create_folder = {@create_folder} />
+                listing             = {listing}
+                page_size           = {@file_listing_page_size()}
+                page_number         = {@props.page_number}
+                file_map            = {file_map}
+                file_search         = {@props.file_search}
+                checked_files       = {@props.checked_files}
+                current_path        = {@props.current_path}
+                public_view         = {public_view}
+                actions             = {@props.actions}
+                create_file         = {@create_file}
+                create_folder       = {@create_folder}
+                selected_file_index = {@props.selected_file_index} />
         else
             <div style={fontSize:'40px', textAlign:'center', color:'#999999'} >
                 <Loading />
@@ -1771,16 +1771,16 @@ ProjectFiles = (name) -> rclass
             <Row>
                 <Col sm=3>
                     <ProjectFilesSearch
-                        key                = {@props.current_path}
-                        file_search        = {@props.file_search}
-                        actions            = {@props.actions}
-                        current_path       = {@props.current_path}
-                        selected_file      = {visible_listing?[@props.selected_file_index]}
-                        selected_file_index= {@props.selected_file_index}
+                        key                 = {@props.current_path}
+                        file_search         = {@props.file_search}
+                        actions             = {@props.actions}
+                        current_path        = {@props.current_path}
+                        selected_file       = {visible_listing?[@props.selected_file_index]}
+                        selected_file_index = {@props.selected_file_index}
                         file_creation_error = {@props.file_creation_error}
                         num_files_displayed = {visible_listing?.length}
-                        create_file        = {@create_file}
-                        create_folder      = {@create_folder} />
+                        create_file         = {@create_file}
+                        create_folder       = {@create_folder} />
                 </Col>
                 {@render_new_file() if not public_view}
                 <Col sm={if public_view then 6 else 4}>

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -386,6 +386,10 @@ NoFiles = rclass
             <Alert style={marginTop: '10px', fontWeight : 'bold'} bsStyle='danger'>
                 Warning: \ is an illegal character
             </Alert>
+        else if @props.file_search.indexOf('/') == 0
+            <Alert style={marginTop: '10px', fontWeight : 'bold'} bsStyle='danger'>
+                Warning: Names cannot begin with /
+            </Alert>
         # Non-empty search and there is a file divisor ('/')
         else if @props.file_search.length > 0 and last_folder_index > 0
             <Alert style={marginTop: '10px'} bsStyle='info'>

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -344,18 +344,21 @@ NoFiles = rclass
 
     displayName : 'ProjectFiles-NoFiles'
 
+    getDefaultProps : ->
+        file_search : ''
+
     # Go to the new file tab if there is no file search
     handle_click : ->
-        if not @props.file_search?.length > 0
+        if @props.file_search.length == 0
             @props.actions.set_focused_page('project-new-file')
-        else if @props.file_search?[@props.file_search.length - 1] == '/'
+        else if @props.file_search[@props.file_search.length - 1] == '/'
             @props.create_folder()
         else
             @props.create_file()
 
     # Returns the full file_search text in addition to the default extension if applicable
     full_path_text : ->
-        if @props.file_search?.lastIndexOf('.') <= @props.file_search?.lastIndexOf('/')
+        if @props.file_search.lastIndexOf('.') <= @props.file_search.lastIndexOf('/')
           ext = "sagews"
         if ext and @props.file_search.slice(-1) isnt '/'
             "#{@props.file_search}.#{ext}"
@@ -364,7 +367,7 @@ NoFiles = rclass
 
     # Text for the large create button
     button_text : ->
-        if not @props.file_search?.length > 0
+        if @props.file_search.length == 0
             "Create or upload files..."
         else
             "Create #{@full_path_text()}"
@@ -378,13 +381,13 @@ NoFiles = rclass
 
     # TODO: Make better help text
     render_help_alert : ->
-        last_folder_index = @props.file_search?.lastIndexOf('/')
-        if @props.file_search? and @props.file_search.indexOf('\\') != -1
+        last_folder_index = @props.file_search.lastIndexOf('/')
+        if @props.file_search.indexOf('\\') != -1
             <Alert style={marginTop: '10px', fontWeight : 'bold'} bsStyle='danger'>
                 Warning: \ is an illegal character
             </Alert>
         # Non-empty search and there is a file divisor ('/')
-        else if @props.file_search?.length > 0 and last_folder_index > 0
+        else if @props.file_search.length > 0 and last_folder_index > 0
             <Alert style={marginTop: '10px'} bsStyle='info'>
                 {@render_help_text(last_folder_index)}
             </Alert>
@@ -432,7 +435,7 @@ NoFiles = rclass
                 <hr/>
                 {@render_create_button() if not @props.public_view}
                 {@render_help_alert()}
-                {@render_file_type_selection() if @props.file_search?.length > 0}
+                {@render_file_type_selection() if @props.file_search.length > 0}
             </Col>
             <Col sm=2>
             </Col>
@@ -457,6 +460,9 @@ FileListing = rclass
         actions       : rtypes.object.isRequired
         create_folder : rtypes.func.isRequired
         create_file   : rtypes.func.isRequired
+
+    getDefaultProps : ->
+        file_search : ''
 
     render_row : (name, size, time, mask, isdir, display_name, public_data, index) ->
         checked = @props.checked_files.has(misc.path_to_file(@props.current_path, name))
@@ -1373,7 +1379,7 @@ ProjectFilesSearch = rclass
         file_search : ''
 
     render_help_info : ->
-        if @props.file_search?.length > 0 and @props.files_displayed
+        if @props.file_search.length > 0 and @props.files_displayed
             firstFolderPosition = @props.file_search.indexOf('/')
             if @props.file_search == '/'
                 text = "Showing all folders in this directory"
@@ -1404,7 +1410,7 @@ ProjectFilesSearch = rclass
             else
                 @props.actions.open_file(path: new_path)
             @props.actions.set_file_search('')
-        else if not @props.files_displayed and @props.file_search?.length > 0
+        else if not @props.files_displayed and @props.file_search.length > 0
             if @props.file_search[@props.file_search.length - 1] == '/'
                 @props.create_folder()
             else
@@ -1448,7 +1454,7 @@ ProjectFilesNew = rclass
         </MenuItem>
 
     on_menu_item_clicked : (ext) ->
-        if not @props.file_search?.length > 0
+        if @props.file_search.length == 0
             # Tell state to render an error in file search
             @props.actions.setState(file_creation_error : "You must enter file name above to create it")
         else
@@ -1456,9 +1462,9 @@ ProjectFilesNew = rclass
 
     # Go to new file tab if no file is specified
     on_create_button_clicked : ->
-        if not @props.file_search?.length > 0
+        if @props.file_search.length == 0
             @props.actions.set_focused_page('project-new-file')
-        else if @props.file_search?[@props.file_search.length - 1] == '/'
+        else if @props.file_search[@props.file_search.length - 1] == '/'
             @props.create_folder()
         else
             @props.create_file()
@@ -1511,6 +1517,7 @@ ProjectFiles = (name) -> rclass
 
     getDefaultProps : ->
         page_number : 0
+        file_search : ''
 
     previous_page : ->
         if @props.page_number > 0
@@ -1520,7 +1527,7 @@ ProjectFiles = (name) -> rclass
         @props.actions.setState(page_number : @props.page_number + 1)
 
     create_file : (ext) ->
-        if not ext? and @props.file_search?.lastIndexOf('.') <= @props.file_search?.lastIndexOf('/')
+        if not ext? and @props.file_search.lastIndexOf('.') <= @props.file_search.lastIndexOf('/')
             ext = "sagews"
         @props.actions.create_file
             name         : @props.file_search

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -287,6 +287,22 @@ class ProjectActions extends Actions
             delete @_set_directory_files_lock[_key] # done!
         )
 
+    # Increases the selected file index by 1
+    # Assumes undefined state to be identical to 0
+    increment_selected_file_index : ->
+        current_index = @get_store().get('selected_file_index') ? 0
+        @setState(selected_file_index : current_index + 1)
+
+    # Decreases the selected file index by 1.
+    # Guaranteed to never set below 0.
+    decrement_selected_file_index : ->
+        current_index = @get_store().get('selected_file_index')
+        if current_index? and current_index > 0
+            @setState(selected_file_index : current_index - 1)
+
+    reset_selected_file_index : ->
+        @setState(selected_file_index : 0)
+
     # Set the most recently clicked checkbox, expects a full/path/name
     set_most_recent_file_click : (file) =>
         @setState(most_recent_file_click : file)


### PR DESCRIPTION
Add some assistance to searching for files allowing users to hit their up and down keys to change the highlighted file that opens if they hit enter.

Selecting and opening a folder should navigate into that folder.

This change also adds warning for attempting to create a file beginning with a `/` or naming files `.` or `.`