### PR TITLE
Add functionality for ctrl+enter in file listing tab

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1591,7 +1591,10 @@ ProjectFiles = (name) -> rclass
         @props.actions.setState(file_creation_error : e)
 
     create_folder : ->
-        @props.actions.create_folder(@props.file_search, @props.current_path, (a) => setState(error: a))
+        @props.actions.create_folder
+            name         : @props.file_search
+            current_path : @props.current_path
+            on_error     : ((a) => setState(error: a))
         @props.actions.setState(file_search : '', page_number: 0)
 
     render_paging_buttons : (num_pages) ->

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1434,7 +1434,6 @@ ProjectFilesSearch = rclass
         @props.actions.setState(file_creation_error : '')
 
     search_submit: ->
-        # TODO: Add visual indication that a file is selected at all.
         if @props.selected_file
             new_path = misc.path_to_file(@props.current_path, @props.selected_file.name)
             if @props.selected_file.isdir
@@ -1449,6 +1448,13 @@ ProjectFilesSearch = rclass
             else
                 @props.create_file()
         @props.actions.reset_selected_file_index()
+
+    ctrl_enter : ->
+        if not @props.selected_file and not @props.files_displayed and @props.file_search.length > 0
+            if @props.file_search[@props.file_search.length - 1] == '/'
+                @props.create_folder(false)
+            else
+                @props.create_file(null, false)
 
     on_up_press : () ->
         if @props.selected_file_index > 0
@@ -1470,6 +1476,7 @@ ProjectFilesSearch = rclass
                 value         = {@props.file_search}
                 on_change     = {@on_change}
                 on_submit     = {@search_submit}
+                on_ctrl_enter = {@ctrl_enter}
                 on_up         = {@on_up_press}
                 on_down       = {@on_down_press}
             />
@@ -1576,7 +1583,7 @@ ProjectFiles = (name) -> rclass
     next_page : ->
         @props.actions.setState(page_number : @props.page_number + 1)
 
-    create_file : (ext) ->
+    create_file : (ext, switch_over=true) ->
         if not ext? and @props.file_search.lastIndexOf('.') <= @props.file_search.lastIndexOf('/')
             ext = "sagews"
         @props.actions.create_file
@@ -1585,17 +1592,25 @@ ProjectFiles = (name) -> rclass
             current_path : @props.current_path
             on_download  : ((a) => @setState(download: a))
             on_error     : @handle_creation_error
+            switch_over  : switch_over
         @props.actions.setState(file_search : '', page_number: 0)
+        if not switch_over
+            # WARNING: Uses old way of refreshing file listing
+            @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)
 
     handle_creation_error : (e) ->
         @props.actions.setState(file_creation_error : e)
 
-    create_folder : ->
+    create_folder : (switch_over=true) ->
         @props.actions.create_folder
             name         : @props.file_search
             current_path : @props.current_path
             on_error     : ((a) => setState(error: a))
+            switch_over  : switch_over
         @props.actions.setState(file_search : '', page_number: 0)
+        if not switch_over
+            # WARNING: Uses old way of refreshing file listing
+            @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)
 
     render_paging_buttons : (num_pages) ->
         if num_pages > 1

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -587,7 +587,14 @@ class ProjectActions extends Actions
             s = "#{s}.#{ext}"
         return s
 
-    create_folder : (name, current_path, on_error) =>
+    create_folder : (opts) =>
+        opts = defaults opts,
+            name         : undefined
+            current_path : undefined
+            on_error     : undefined
+
+        {name, current_path, on_error} = opts
+
         if name[name.length - 1] == '/'
             name = name.slice(0, -1)
         p = @path(name, current_path, undefined, undefined, on_error)
@@ -621,7 +628,10 @@ class ProjectActions extends Actions
             return
         if name[name.length - 1] == '/'
             if not opts.ext?
-                @create_folder(name, opts.current_path, opts.on_error)
+                @create_folder
+                    name          : name
+                    current_path  : opts.current_path
+                    on_error      : opts.on_error
                 return
             else
                 name = name.slice(0, name.length - 1)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -592,8 +592,9 @@ class ProjectActions extends Actions
             name         : undefined
             current_path : undefined
             on_error     : undefined
+            switch_over  : true       # Whether or not to switch to the new folder
 
-        {name, current_path, on_error} = opts
+        {name, current_path, on_error, switch_over} = opts
 
         if name[name.length - 1] == '/'
             name = name.slice(0, -1)
@@ -603,7 +604,7 @@ class ProjectActions extends Actions
         @ensure_directory_exists
             path : p
             cb   : (err) =>
-                if not err
+                if not err and switch_over
                     #TODO reporting of errors...
                     @set_current_path(p)
                     @set_focused_page('project-file-listing')
@@ -616,6 +617,7 @@ class ProjectActions extends Actions
             on_download  : undefined
             on_error     : undefined
             on_empty     : undefined
+            switch_over  : true       # Whether or not to switch to the new file
 
         name = opts.name
         if (name == ".." or name == ".") and not opts.ext?
@@ -658,7 +660,7 @@ class ProjectActions extends Actions
             cb          : (err, output) =>
                 if err
                     opts.on_error?("#{output?.stdout ? ''} #{output?.stderr ? ''} #{err}")
-                else
+                else if opts.switch_over
                     @set_focused_page('project-editor')
                     tab = @create_editor_tab(filename:p, content:'')
                     @display_editor_tab(path: p)

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -487,6 +487,7 @@ exports.SearchInput = rclass
         value           : rtypes.string
         on_change       : rtypes.func    # called on_change(value) each time the search input changes
         on_submit       : rtypes.func    # called on_submit(value) when the search input is submitted (by hitting enter)
+        on_ctrl_enter   : rtypes.func    # called on_ctrl_enter(value) when the enter key is hit while pressing ctrl
         on_escape       : rtypes.func    # called when user presses escape key; on_escape(value *before* hitting escape)
         autoFocus       : rtypes.bool
         autoSelect      : rtypes.bool
@@ -526,7 +527,7 @@ exports.SearchInput = rclass
         if @props.clear_on_submit
             @setState(value:'')
 
-    keydown : (e) ->
+    keyDown : (e) ->
         switch e.keyCode
             when 27
                 @escape()
@@ -534,6 +535,9 @@ exports.SearchInput = rclass
                 @props.on_down?()
             when 38
                 @props.on_up?()
+            when 13 # Enter Key
+                if e.ctrlKey
+                    @props.on_ctrl_enter?(@state.value)
 
     escape : ->
         @props.on_escape?(@state.value)
@@ -549,7 +553,7 @@ exports.SearchInput = rclass
                 value       = {@state.value}
                 buttonAfter = {@clear_search_button()}
                 onChange    = {=>@set_value(@refs.input.getValue())}
-                onKeyDown   = {@keydown}
+                onKeyDown   = {@keyDown}
             />
         </form>
 


### PR DESCRIPTION
Mostly matches the behavior for hitting enter while in the file listing tab with the following exceptions:
- Does not open up any newly created files
- Does not navigate to any newly created folders
- Does nothing when there are files displayed even if the search bar is non-empty

I have considered to cause it to create the file anyways even if there are search results. Sort of as a "force file creation". However, this might just confuse users since it would default to a sage worksheet without any indication. This probably falls under power user functionality though?