### PR TITLE
storage/process_update: async-serializing update_db → action → update_db and afterwards clearing tasks[project_id] indicator

### DIFF
--- a/src/smc-hub/storage.coffee
+++ b/src/smc-hub/storage.coffee
@@ -1285,7 +1285,7 @@ process_update = (tasks, database, project) ->
                 storage_request.err = err
             update_db () ->
                 tasks[project.project_id] = false
-                cb_async?()
+                opts.cb_async?()
     func = err = undefined
     switch action
         when 'save'


### PR DESCRIPTION
this might help with getting excessive project open requests under control (it might not solve it, but makes this function more predictable and easier to reason about)