### PR TITLE
Remove duplicates in Sage and R package lists

### DIFF
--- a/src/smc-build/build.py
+++ b/src/smc-build/build.py
@@ -164,7 +164,6 @@ SAGE_PIP_PACKAGES = [
     'bitarray',
     'h5py',
     'netcdf4',
-    'patsy',
     'lxml',
     'munkres',
     'oct2py',
@@ -211,7 +210,6 @@ SAGE_PIP_PACKAGES = [
     'mrjob',
     'boto',
     'pattern',
-    'seaborn',
     'brewer2mpl',
     'ggplot',
     'periodictable',
@@ -224,7 +222,6 @@ SAGE_PIP_PACKAGES = [
     'snappy',
     'twitter',
     'bayespy==0.3.6',   # last version that supports Python2 -- 0.4.x on is Python3 only!
-    'astropy',
     'aplpy',
     'PyDSTool',
     'progressbar',  # requested by David Lisbonne
@@ -236,7 +233,6 @@ SAGE_PIP_PACKAGES = [
     'pystan',
     'biopython',
     'guppy',
-    'nose',
     'pybtex',
     'bokeh',
     'numba',
@@ -299,7 +295,6 @@ R_PACKAGES = [
     'ROCR',
     'forecast',
     'numDeriv',
-    'Matrix',
     'NORMT3',
     'ggmap',
     'np',
@@ -309,7 +304,6 @@ R_PACKAGES = [
     'maptree',
     'agricolae',
     'nortest',
-    'forecast',
     'gplots',
     'Hmisc',
     'survey',
@@ -351,7 +345,6 @@ SAGE_OPTIONAL_PACKAGES = [
     'topcom',
     '4ti2',
     'modular_decomposition',
-    'topcom',
     'csdp'    # experimental; non-GPL compatible, but that is OK as we are not distributing.  commercial use encouraged.
 ]
 


### PR DESCRIPTION
Remove duplicates (last occurrence) in
- SAGE_PIP_PACKAGES: astropy, nose, patsy, seaborn
- R_PACKAGES: Matrix, forecast
- SAGE_OPTIONAL_PACKAGES: topcom