### PR TITLE
use server clock rather than user clock for timestamps in various places in SMC client code and display a warning if the user's clock is off by > 1 minute.

### DIFF
--- a/src/smc-webapp/alerts.coffee
+++ b/src/smc-webapp/alerts.coffee
@@ -21,6 +21,7 @@
 
 
 {defaults, to_json} = require("misc")
+{salvus_client} = require('./salvus_client')
 
 types = ['error', 'default', 'success', 'info']
 default_timeout =
@@ -82,10 +83,11 @@ exports.alert_message = (opts={}) ->
 
     # setTimeout((()->c.remove()), opts.timeout*1000)
 
+local_time = new Date()
+if Math.abs(salvus_client.server_time() - local_time) > 60000
+    exports.alert_message(type:'error', timeout:30,  message:"Your computer's clock is off by over a minute. Please fix it.")
 # for testing/development
 # alert_message(type:'error',   message:"This is an error")
 # alert_message(type:'default', message:"This is a default alert")
 # alert_message(type:'success', message:"This is a success alert")
 # alert_message(type:'info',    message:"This is an info alert")
-
-

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -19,9 +19,10 @@
 #
 ###############################################################################
 
-async     = require('async')
-misc      = require('smc-util/misc')
-_         = require('underscore')
+async         = require('async')
+misc          = require('smc-util/misc')
+salvus_client = require('./salvus_client')
+_             = require('underscore')
 
 {redux, rclass, React, ReactDOM, rtypes, Redux, Actions, Store}  = require('./smc-react')
 

--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -1619,7 +1619,7 @@ BillingPage = rclass
         </div>
 
     render_course_payment_required: (project, pay) ->
-        if pay <= new Date()
+        if pay <= salvus_client.server_time()
             style = "danger"
             due = <span>now</span>
         else

--- a/src/smc-webapp/editor_course.cjsx
+++ b/src/smc-webapp/editor_course.cjsx
@@ -453,7 +453,7 @@ exports.init_redux = init_redux = (redux, course_project_id, course_filename) ->
             store = get_store()
             return if not store?
             student_id = store.get_student(student).get('student_id')
-            @_update(set:{create_project:new Date()}, where:{table:'students',student_id:student_id})
+            @_update(set:{create_project:salvus_client.server_time()}, where:{table:'students',student_id:student_id})
             id = @set_activity(desc:"Create project for #{store.get_student_name(student_id)}.")
             token = misc.uuid()
             redux.getActions('projects').create_project
@@ -913,7 +913,7 @@ exports.init_redux = init_redux = (redux, course_project_id, course_filename) ->
                 where = {table:'assignments', assignment_id:assignment.get('assignment_id')}
                 x = syncdb.select_one(where:where)?[type] ? {}
                 y = (x[student.get('student_id')]) ? {}
-                if y.start? and new Date() - y.start <= 15000
+                if y.start? and salvus_client.server_time() - y.start <= 15000
                     return true  # never retry a copy until at least 15 seconds later.
                 y.start = misc.mswalltime()
                 x[student.get('student_id')] = y
@@ -1670,7 +1670,7 @@ Student = rclass
         create = @props.student.get("create_project")
         if create?
             # if so, how long ago did it start
-            how_long = (new Date() - create)/1000
+            how_long = (salvus_client.server_time() - create)/1000
             if how_long < 120 # less than 2 minutes -- still hope, so render that creating
                 return <div><Icon name="circle-o-notch" spin /> Creating project...(started <TimeAgo date={create} />)</div>
             # otherwise, maybe user killed file before finished or something and it is lost; give them the chance
@@ -2439,7 +2439,7 @@ Assignment = rclass
             </Col>
             <Col xs=11>
                 <DateTimePicker
-                    value     = {@props.assignment.get('due_date') ? new Date()}
+                    value     = {@props.assignment.get('due_date') ? salvus_client.server_time()}
                     on_change = {@date_change}
                 />
             </Col>
@@ -3247,7 +3247,7 @@ Settings = rclass
         students = store.get_sorted_students()
         # CSV definition: http://edoceo.com/utilitas/csv-file-format
         # i.e. double quotes everywhere (not single!) and double quote in double quotes usually blows up
-        timestamp  = (new Date()).toISOString()
+        timestamp  = (salvus_client.server_time()).toISOString()
         content = "# Course '#{@props.settings.get('title')}'\n"
         content += "# exported #{timestamp}\n"
         content += "Name,Email,"
@@ -3271,7 +3271,7 @@ Settings = rclass
             {'name':'Bar None', 'email': 'bar@school.edu', 'grades':[15,50]},
         ]
         ###
-        timestamp = (new Date()).toISOString()
+        timestamp = (salvus_client.server_time()).toISOString()
         store = @props.redux.getStore(@props.name)
         assignments = store.get_sorted_assignments()
         students = store.get_sorted_students()
@@ -3731,7 +3731,7 @@ Settings = rclass
         </Button>
 
     render_require_students_pay_desc: (date) ->
-        if date > new Date()
+        if date > salvus_client.server_time()
             <span>
                 Your students will see a warning until <TimeAgo date={date} />.  They will then be required to upgrade for a one-time fee of $9.
             </span>
@@ -3790,7 +3790,7 @@ Settings = rclass
 
     render_students_pay_checkbox_label: ->
         if @state.students_pay
-            if new Date() >= @state.students_pay_when
+            if salvus_client.server_time() >= @state.students_pay_when
                 <span>Require that students upgrade immediately:</span>
             else
                 <span>Require that students upgrade by <TimeAgo date={@state.students_pay_when} />: </span>

--- a/src/smc-webapp/file_use.cjsx
+++ b/src/smc-webapp/file_use.cjsx
@@ -110,7 +110,7 @@ class FileUseActions extends Actions
         # This should get displayed to the user...
         if not typeof(err) == 'string'
             err = misc.to_json(err)
-        @setState(errors: @redux.getStore('file_use').get_errors().push(immutable.Map({time:new Date(), err:err})))
+        @setState(errors: @redux.getStore('file_use').get_errors().push(immutable.Map({time:salvus_client.server_time(), err:err})))
 
     mark_all: (action) =>
         if action == 'read'
@@ -146,7 +146,7 @@ class FileUseActions extends Actions
             setTimeout((()=>delete @_mark_file_lock[key]), ttl)
 
         table = @redux.getTable('file_use')
-        now   = new Date()
+        now   = salvus_client.server_time()
         obj   =
             project_id : project_id
             path       : path

--- a/src/smc-webapp/file_use.cjsx
+++ b/src/smc-webapp/file_use.cjsx
@@ -92,7 +92,7 @@ immutable = require('immutable')
 
 # smc-specific modules
 misc = require('smc-util/misc')
-
+salvus_client = require('./salvus_client')
 editor = require('./editor')
 
 # react in smc-specific modules

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -34,6 +34,7 @@ account               = require('./account')
 {top_navbar}          = require('./top_navbar')
 immutable             = require('immutable')
 underscore            = require('underscore')
+salvus_client         = require('./salvus_client')
 
 Combobox = require('react-widgets/lib/Combobox') #TODO: delete this when the combobox is in r_misc
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1775,7 +1775,7 @@ ProjectFiles = (name) -> rclass
         projects_store = @props.redux.getStore('projects')  # component depends on this so OK
 
         pay = projects_store.date_when_course_payment_required(@props.project_id)
-        if pay? and pay <= new Date()
+        if pay? and pay <= salvus_client.server_time()
             return @render_course_payment_required()
 
         # TODO: public_view is *NOT* a function of the props of this component. This is bad, but we're

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -55,7 +55,7 @@ class ProjectsActions extends Actions
             @setState(project_state: store.get('project_state').set(project_id, x.delete(name)))
 
     set_project_state_open : (project_id, err) =>
-        @set_project_state(project_id, 'open', {time:new Date(), err:err})
+        @set_project_state(project_id, 'open', {time:salvus_client.server_time(), err:err})
 
     set_project_state_close : (project_id) =>
         @delete_project_state(project_id, 'open')
@@ -122,7 +122,7 @@ class ProjectsActions extends Actions
                 projects_owner :
                     project_id : project_id
                     course     :
-                        paying     : new Date()
+                        paying     : salvus_client.server_time()
             cb : cb
 
     # Create a new project
@@ -195,7 +195,7 @@ class ProjectsActions extends Actions
                 obj =
                     error   : err
                     tree    : resp?.directories.sort()
-                    updated : new Date()
+                    updated : salvus_client.server_time()
                 @setState(directory_trees: x.set(project_id, immutable.fromJS(obj)))
 
     # The next few actions below involve changing the users field of a project.
@@ -264,27 +264,27 @@ class ProjectsActions extends Actions
     save_project: (project_id) =>
         @redux.getTable('projects').set
             project_id     : project_id
-            action_request : {action:'save', time:new Date()}
+            action_request : {action:'save', time:salvus_client.server_time()}
 
     stop_project: (project_id) =>
         @redux.getTable('projects').set
             project_id     : project_id
-            action_request : {action:'stop', time:new Date()}
+            action_request : {action:'stop', time:salvus_client.server_time()}
 
     close_project_on_server: (project_id) =>  # not used by UI yet - dangerous
         @redux.getTable('projects').set
             project_id     : project_id
-            action_request : {action:'close', time:new Date()}
+            action_request : {action:'close', time:salvus_client.server_time()}
 
     restart_project : (project_id) ->
         @redux.getTable('projects').set
             project_id     : project_id
-            action_request : {action:'restart', time:new Date()}
+            action_request : {action:'restart', time:salvus_client.server_time()}
 
     start_project : (project_id) ->
         @redux.getTable('projects').set
             project_id     : project_id
-            action_request : {action:'start', time:new Date()}
+            action_request : {action:'start', time:salvus_client.server_time()}
 
     # Toggle whether or not project is hidden project
     set_project_hide : (account_id, project_id, state) =>
@@ -376,7 +376,7 @@ class ProjectsStore extends Store
             # signed in user is the student
             pay = info.get('pay')
             if pay
-                if new Date() >= misc.months_before(-3, pay)
+                if salvus_client.server_time() >= misc.months_before(-3, pay)
                     # It's 3 months after date when sign up required, so course likely over,
                     # and we no longer require payment
                     return

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -31,6 +31,7 @@ immutable  = require('immutable')
 underscore = require('underscore')
 
 markdown = require('./markdown')
+salvus_client = require('./salvus_client')
 
 # base unit in pixel for margin/size/padding
 exports.UNIT = UNIT = 15

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -910,7 +910,7 @@ exports.DirectoryInput = rclass
 
     render : ->
         x = @props.directory_trees?.get(@props.project_id)?.toJS()
-        if not x? or new Date() - x.updated >= 15000
+        if not x? or salvus_client.server_time() - x.updated >= 15000
             @props.redux.getActions('projects').fetch_directory_tree(@props.project_id)
         tree = x?.tree
         if tree?
@@ -942,7 +942,7 @@ exports.DeletedProjectWarning = ->
 exports.course_warning = (pay) ->
     if not pay
         return false
-    return new Date() <= misc.months_before(-3, pay)  # require subscription until 3 months after start (an estimate for when class ended, and less than when what student did pay for will have expired).
+    return salvus_client.server_time() <= misc.months_before(-3, pay)  # require subscription until 3 months after start (an estimate for when class ended, and less than when what student did pay for will have expired).
 
 project_warning_opts = (opts) ->
     {upgrades_you_can_use, upgrades_you_applied_to_all_projects, course_info, account_id, email_address} = opts
@@ -971,7 +971,7 @@ exports.CourseProjectWarning = (opts) ->
     else
         action = <billing.BillingPageLink text="buy a course subscription" />
     is_student = account_id == course_info.get('account_id') or email_address == course_info.get('email_address')
-    if pay > new Date()  # in the future
+    if pay > salvus_client.server_time()  # in the future
         if is_student
             deadline  = <span>Your instructor requires you to {action} within <TimeAgo date={pay}/>.</span>
         else


### PR DESCRIPTION
Here's an example commit along these lines: 

https://github.com/sagemathinc/smc/commit/d12bac9edacb5b7a88135707bfa389eb58addedc