### PR TITLE
webpack/webapp+hub: hardcode BASE_URL during compilation

### DIFF
--- a/src/webapp-lib/index.jade
+++ b/src/webapp-lib/index.jade
@@ -58,8 +58,13 @@ html
     div#smc-startup-banner-status
       | Initializing ...
 
-    //- this sets the base_url
-    script(type="text/javascript" src="base_url.js")
+    //- this sets the global window.smc_base_url: either statically via the BASE_URL template variable, or dynamically via hub
+    - var BASE_URL = htmlWebpackPlugin.options.BASE_URL
+    if typeof BASE_URL !== "undefined" && BASE_URL !== null
+        script(type="text/javascript").
+            window.smc_base_url='#{BASE_URL}';
+    else
+        script(type="text/javascript" src="base_url.js")
 
     script(type="text/javascript").
         function smcLoadStatus(msg) {

--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -192,10 +192,18 @@ htmlMinifyOpts =
     collapseWhitespace : true
     conservativeCollapse : true
 
+# when base_url_html is set, it is hardcoded into the index page
+# it mimics the logic of the hub, where all trailing slashes are removed
+# i.e. the production page has a base url of '' and smc-in-smc has '/.../...'
+base_url_html = BASE_URL # do *not* modify BASE_URL, it's needed with a '/' down below
+while base_url_html and base_url_html[base_url_html.length-1] == '/'
+    base_url_html = base_url_html.slice(0, base_url_html.length-1)
+
 # this is the main indes.html file, which should be served without any caching
 jade2html = new HtmlWebpackPlugin
                         date     : BUILD_DATE
                         title    : TITLE
+                        BASE_URL : base_url_html
                         git_rev  : GIT_REV
                         mathjax  : MATHJAX_URL
                         filename : 'index.html'


### PR DESCRIPTION
this patch hardcodes the global smc_base_url and hence saves one round trip to the hub. it also makes sure, that in the case of the production website, the "/" is actually ending up as an empty string, such that `smc_base_url + '/some/abs/path'` in the webapp codebase does work. 