### PR TITLE
Make autoscroll happen on submit and not keydown

### DIFF
--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -235,11 +235,11 @@ ChatRoom = (name) -> rclass
         input : ''
 
     keydown : (e) ->
-        @scroll_to_bottom()
         if e.keyCode==27 # ESC
             e.preventDefault()
             @clear_input()
         else if e.keyCode==13 and not e.shiftKey # 13: enter key
+            @scroll_to_bottom()
             e.preventDefault()
             mesg = @refs.input.getValue()
             # block sending empty messages


### PR DESCRIPTION
No other chat program I know of scrolls to the bottom on entering text. All of them do it on submit. The current behavior makes it impossible to view an old message and type a response at the same time.