### PR TITLE
Analytics token in configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,6 @@ src/smc_sagews/build/*
 logs
 pids
 
+src/k8s/smc-webapp-static/image/google_analytics
+
 .gitignore

--- a/src/k8s/smc-webapp-static/control.py
+++ b/src/k8s/smc-webapp-static/control.py
@@ -9,6 +9,10 @@ os.chdir(SCRIPT_PATH)
 sys.path.insert(0, os.path.abspath(os.path.join(SCRIPT_PATH, '..', 'util')))
 import util
 
+# analytics token optionally stored in src/data/config/google_analytics
+# if doesn't exist, don't copy anything
+ga_fn = os.path.abspath(os.path.join(SCRIPT_PATH, '..', '..', 'data', 'config', 'google_analytics'))
+
 # For now in all cases, we just call the container the following; really it should
 # maybe be smc-webapp-static#sha1hash, which makes switching between versions easy, etc.
 NAME='smc-webapp-static'
@@ -32,6 +36,12 @@ def build(tag, rebuild, commit=None):
 
     # Build image we will deploy on top of base
     v = ['sudo', 'docker', 'build', '-t', tag]
+
+    ga = '' # default must be an empty file, otherwise docker complains
+    if os.path.exists(ga_fn):
+        ga = open(ga_fn).read().strip()
+    open(os.path.join(SCRIPT_PATH, 'image', 'google_analytics'), 'w').write(ga)
+
     if commit:
         v.append("--build-arg")
         v.append("commit={commit}".format(commit=commit))

--- a/src/k8s/smc-webapp-static/image/Dockerfile
+++ b/src/k8s/smc-webapp-static/image/Dockerfile
@@ -8,6 +8,9 @@ ARG commit=HEAD
 # Configuration of NGINX
 COPY default.conf /etc/nginx/conf.d/default.conf
 
+# Optional GA token (needs to be an empty file if not set)
+COPY google_analytics /smc/src/data/config/
+
 # Pull latest version of code and rebuild
 RUN cd /smc/src && . ./smc-env && git pull && git fetch origin && git checkout ${commit:-HEAD} && ./install.py webapp build
 

--- a/src/smc-util-node/misc_node.coffee
+++ b/src/smc-util-node/misc_node.coffee
@@ -898,3 +898,8 @@ if exports.SALVUS_HOME?
     exports.MATHJAX_NOVERS   = path.join(exports.OUTPUT_DIR, "mathjax")
     # this is where the webapp and the jupyter notebook should get mathjax from
     exports.MATHJAX_URL      = path.join(exports.BASE_URL, exports.MATHJAX_ROOT, 'MathJax.js')
+
+    # google analytics (or later on some other analytics provider) needs a token as a parameter
+    # if defined in data/config/google_analytics, tell webpack about it.
+    ga_snippet_fn            = path.join(exports.SALVUS_HOME, 'data', 'config', 'google_analytics')
+    exports.GOOGLE_ANALYTICS = if fs.existsSync(ga_snippet_fn) then fs.readFileSync(ga_snippet_fn).toString().trim() else null

--- a/src/smc-util-node/misc_node.coffee
+++ b/src/smc-util-node/misc_node.coffee
@@ -902,4 +902,11 @@ if exports.SALVUS_HOME?
     # google analytics (or later on some other analytics provider) needs a token as a parameter
     # if defined in data/config/google_analytics, tell webpack about it.
     ga_snippet_fn            = path.join(exports.SALVUS_HOME, 'data', 'config', 'google_analytics')
-    exports.GOOGLE_ANALYTICS = if fs.existsSync(ga_snippet_fn) then fs.readFileSync(ga_snippet_fn).toString().trim() else null
+    # file could contain the token or nothing (empty string, see k8s/smc-webapp-static)
+    ga = null
+    if fs.existsSync(ga_snippet_fn)
+        token = fs.readFileSync(ga_snippet_fn).toString().trim()
+        if token.length > 0
+            ga = token
+    exports.GOOGLE_ANALYTICS = ga
+

--- a/src/smc-webapp/account.coffee
+++ b/src/smc-webapp/account.coffee
@@ -58,7 +58,8 @@ load_app = (cb) ->
         cb()
 
 signed_in = (mesg) ->
-    ga('send', 'event', 'account', 'signed_in')    # custom google analytic event -- user signed in
+    {analytics_event} = require('./misc_page')
+    analytics_event('account', 'signed_in')    # user signed in
     # Record which hub we're connected to.
     redux.getActions('account').setState(hub: mesg.hub)
 

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1552,12 +1552,13 @@ exports.analytics = (type, args...) ->
     # GoogleAnalyticsObject contains the possibly customized function name of GA.
     # It's a good idea to call it differently from the default 'ga' to avoid name clashes...
     if window.GoogleAnalyticsObject?
-        switch type
-            when 'event', 'pageview'
-                ga = window[window.GoogleAnalyticsObject]
-                ga('send', type, args...)
-            else
-                console.warn("unknown analytics event '#{type}'")
+        ga = window[window.GoogleAnalyticsObject]
+        if ga?
+            switch type
+                when 'event', 'pageview'
+                    ga('send', type, args...)
+                else
+                    console.warn("unknown analytics event '#{type}'")
 
 exports.analytics_pageview = (args...) ->
     exports.analytics('pageview', args...)

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1543,3 +1543,24 @@ return _sanitize_html_lib html,
         allowedTags: _sanitize_html_allowedTags
         allowedAttributes: _sanitize_html_allowedAttributes
 ###
+
+# `analytics` is a generalized wrapper for reporting data to google analytics, pwiki, parsley, ...
+# for now, it either does nothing or works with GA
+# this API basically allows to send off events by name and category
+
+exports.analytics = (type, args...) ->
+    # GoogleAnalyticsObject contains the possibly customized function name of GA.
+    # It's a good idea to call it differently from the default 'ga' to avoid name clashes...
+    if window.GoogleAnalyticsObject?
+        switch type
+            when 'event', 'pageview'
+                ga = window[window.GoogleAnalyticsObject]
+                ga('send', type, args...)
+            else
+                console.warn("unknown analytics event '#{type}'")
+
+exports.analytics_pageview = (args...) ->
+    exports.analytics('pageview', args...)
+
+exports.analytics_event = (args...) ->
+    exports.analytics('event', args...)

--- a/src/smc-webapp/project.coffee
+++ b/src/smc-webapp/project.coffee
@@ -536,11 +536,12 @@ class ProjectPage
             return
 
         @editor.open opts.path, (err, opened_path) =>
+            # {analytics_event} = require('./misc_page')
             if err
-                # ga('send', 'event', 'file', 'open', 'error', opts.path, {'nonInteraction': 1})
+                # analytics_event('file', 'open', 'error', opts.path, {'nonInteraction': 1})
                 alert_message(type:"error", message:"Error opening '#{opts.path}' -- #{misc.to_json(err)}", timeout:10)
             else
-                # ga('send', 'event', 'file', 'open', 'success', opts.path, {'nonInteraction': 1})
+                # analytics_event('file', 'open', 'success', opts.path, {'nonInteraction': 1})
                 if opts.foreground
                     @display_tab("project-editor")
 

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -108,7 +108,8 @@ class ProjectActions extends Actions
             url = ''
         @_last_history_state = url
         window.history.pushState("", "", window.smc_base_url + '/projects/' + @project_id + '/' + misc.encode_path(url))
-        ga('send', 'pageview', window.location.pathname)
+        {analytics_pageview} = require('./misc_page')
+        analytics_pageview(window.location.pathname)
 
     set_next_default_filename : (next) =>
         @setState(default_filename: next)

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -66,7 +66,8 @@ class AccountActions extends Actions
                     when "account_creation_failed"
                         @setState('sign_up_error': mesg.reason)
                     when "signed_in"
-                        ga('send', 'event', 'account', 'create_account')    # custom google analytic event -- user created an account
+                        {analytics_event} = require('./misc_page')
+                        analytics_event('account', 'create_account') # user created an account
                         require('./top_navbar').top_navbar.switch_to_page('projects')
                     else
                         # should never ever happen
@@ -103,7 +104,8 @@ class AccountActions extends Actions
         evt = 'sign_out'
         if everywhere
             evt += '_everywhere'
-        ga('send', 'event', 'account', evt)    # custom google analytic event -- user explicitly signed out.
+        {analytics_event} = require('./misc_page')
+        analytics_event('account', evt)  # user explicitly signed out.
 
         # Send a message to the server that the user explicitly
         # requested to sign out.  The server must clean up resources

--- a/src/smc-webapp/top_navbar.coffee
+++ b/src/smc-webapp/top_navbar.coffee
@@ -169,7 +169,8 @@ class TopNavbar  extends EventEmitter
         # We still call show even if already on this page.
         n.page?.show()
         n.onshow?()
-        ga('send', 'pageview', window.location.pathname)
+        {analytics_pageview} = require('./misc_page')
+        analytics_pageview(window.location.pathname)
 
     activity_indicator: (id) =>
         if not id?

--- a/src/webapp-lib/index.jade
+++ b/src/webapp-lib/index.jade
@@ -110,16 +110,32 @@ html
         });
     script(src="#{ htmlWebpackPlugin.options.mathjax }?delayStartupUntil=configured")
 
-    script(type="text/javascript").
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-34321400-1', 'auto');
-        ga('send', 'pageview');
-
     //- Billing related functionality
     script(type="text/javascript" src="https://js.stripe.com/v2/")
+
+    //- if we have a GA token, insert the google analytics async script
+    - var GOOGLE_ANALYTICS = htmlWebpackPlugin.options.GOOGLE_ANALYTICS
+    if typeof GOOGLE_ANALYTICS !== "undefined" && GOOGLE_ANALYTICS !== null
+        //--- Google Analytics ---
+        script.
+            //- Instructs analytics.js to use the name `google_analytics`.
+            window.GoogleAnalyticsObject = 'google_analytics';
+            //- Creates an initial analytics() function.
+            //- The queued commands will be executed once analytics.js loads.
+            window.google_analytics = window.google_analytics || function() {
+              (google_analytics.q = google_analytics.q || []).push(arguments)
+            };
+            //- Sets the time (as an integer) this tag was executed.
+            //- Used for timing hits.
+            google_analytics.l = +new Date;
+            //- Creates a default tracker with automatic cookie domain configuration.
+            google_analytics('create', '#{GOOGLE_ANALYTICS}', 'auto');
+            //- Sends a pageview hit from the tracker just created.
+            google_analytics('send', 'pageview');
+
+        <!-- Sets the `async` attribute to load the script asynchronously. -->
+        script(async src='//www.google-analytics.com/analytics.js')
+        //--- End Google Analytics ---
 
     //- Hidden div to accurately determine if page is in responsive mode
     div.salvus-responsive-mode-test

--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -109,15 +109,17 @@ SOURCE_MAP    = !! process.env.SOURCE_MAP
 date          = new Date()
 BUILD_DATE    = date.toISOString()
 BUILD_TS      = date.getTime()
+GOOGLE_ANALYTICS = misc_node.GOOGLE_ANALYTICS
 
 # create a file base_url to set a base url
 BASE_URL      = misc_node.BASE_URL
-console.log "SMC_VERSION  = #{SMC_VERSION}"
-console.log "SMC_GIT_REV  = #{GIT_REV}"
-console.log "NODE_ENV     = #{NODE_ENV}"
-console.log "BASE_URL     = #{BASE_URL}"
-console.log "INPUT        = #{INPUT}"
-console.log "OUTPUT       = #{OUTPUT}"
+console.log "SMC_VERSION      = #{SMC_VERSION}"
+console.log "SMC_GIT_REV      = #{GIT_REV}"
+console.log "NODE_ENV         = #{NODE_ENV}"
+console.log "BASE_URL         = #{BASE_URL}"
+console.log "INPUT            = #{INPUT}"
+console.log "OUTPUT           = #{OUTPUT}"
+console.log "GOOGLE_ANALYTICS = #{GOOGLE_ANALYTICS}"
 
 # mathjax version → symlink with version info from package.json/version
 MATHJAX_URL    = misc_node.MATHJAX_URL  # from where the files are served
@@ -201,16 +203,17 @@ while base_url_html and base_url_html[base_url_html.length-1] == '/'
 
 # this is the main indes.html file, which should be served without any caching
 jade2html = new HtmlWebpackPlugin
-                        date     : BUILD_DATE
-                        title    : TITLE
-                        BASE_URL : base_url_html
-                        git_rev  : GIT_REV
-                        mathjax  : MATHJAX_URL
-                        filename : 'index.html'
-                        chunksSortMode: smcChunkSorter
-                        hash     : PRODMODE
-                        template : path.join(INPUT, 'index.jade')
-                        minify   : htmlMinifyOpts
+                        date             : BUILD_DATE
+                        title            : TITLE
+                        BASE_URL         : base_url_html
+                        git_rev          : GIT_REV
+                        mathjax          : MATHJAX_URL
+                        filename         : 'index.html'
+                        chunksSortMode   : smcChunkSorter
+                        hash             : PRODMODE
+                        template         : path.join(INPUT, 'index.jade')
+                        minify           : htmlMinifyOpts
+                        GOOGLE_ANALYTICS : GOOGLE_ANALYTICS
 
 # the following set of plugins renders the policy pages
 # they do *not* depend on any of the chunks, but rather specify css and favicon dependencies


### PR DESCRIPTION
this patch leads to a webapp codebase, where our analytics token is no longer hardcoded. if a file data/config/google_analytics is present and stores the token, it is inserted in the template -- otherwise no reporting. 

also, in case of errors (script is blocked on a DNS level, etc.) it doesn't cause exceptions in the webapp.

I've also added some handling for dealing with the dockerimages. not sure what the best way would be, this below is at least a working one. I've created the image `analytics-token-cc288f` and deployed it on test.* ... where I verified that it is really there and reporting.

PS: don't mix this up with a similarly looking image name from the commit before that -- and what's the proper way to delete an image?