### PR TITLE
Autofocus email in sign-in form always

### DIFF
--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -111,7 +111,7 @@ SignUp = rclass
             <AccountCreationEmailInstructions />
             <form style={marginTop: 20, marginBottom: 20} onSubmit={@make_account}>
                 {@display_error("first_name")}
-                <Input ref='name' type='text' autoFocus={not @props.has_account} placeholder='First and last Name' />
+                <Input ref='name' type='text' autoFocus={false} placeholder='First and last Name' />
                 {@display_error("email_address")}
                 <Input ref='email' type='email' placeholder='Email address' />
                 {@display_error("password")}
@@ -160,7 +160,7 @@ SignIn = rclass
             <form onSubmit={@sign_in} className='form-inline' style={marginRight : 0, marginTop : 2 * UNIT}>
                 <Row>
                     <Col xs=5 style={paddingRight:'2px'}>
-                        <Input style={marginRight: UNIT, width:'100%'} ref='email' type='email' placeholder='Email address' autoFocus={@props.has_account} onChange={@remove_error} />
+                        <Input style={marginRight: UNIT, width:'100%'} ref='email' type='email' placeholder='Email address' autoFocus={true} onChange={@remove_error} />
                     </Col>
                     <Col xs=4 style={paddingLeft:'0px', paddingRight:'0px'}>
                         <Input style={marginRight: UNIT, width:'100%'} ref='password' type='password' placeholder='Password' onChange={@remove_error} />


### PR DESCRIPTION
For discussion on whether or not this is a good idea.

I argue that FB does it and our sign up is based on theirs. Also since the sign-up area is so large, a new user is less likely need help finding it. 

On my sample size of 3, autofocusing the email bar makes it immediately obvious where to sign in. Otherwise it is not.

I could be totally wrong. 
- @timothyclemansinsea Wants to merge the two forms. 
- I think that's more confusing.