### PR TITLE
Enable search bar to behave like mini terminal.

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -349,14 +349,14 @@ DirectoryRow = rclass
 
 TerminalModeDisplay = rclass
     render : ->
-        <Row style={textAlign:'left', color:'#888', marginTop:'20px', wordWrap:'break-word'} >
+        <Row style={textAlign:'left', color:'#888', marginTop:'5px', wordWrap:'break-word'} >
             <Col sm=2>
             </Col>
             <Col sm=8>
-                <Alert style={marginTop: '10px', fontWeight : 'bold'} bsStyle='danger'>
-                Warning: You are in terminal mode.<br/><br/>
-                This was caused by the leading / in your file search. If you would instead like to see just your folders, enter a space in front of the /.<br/>
-                Terminal mode in file listing is experimental and comes with no guarantees about its usability or future existence.
+                <Alert style={marginTop: '5px', fontWeight : 'bold'} bsStyle='danger'>
+                Warning: You are in terminal mode.<br/>
+                This was caused by the leading / in your file search. If you want to just see your folders, enter a space in front of the /.<br/>
+                Terminal mode inside the search bar is experimental and comes with no guarantees about its usability or future existence.
             </Alert>
             </Col>
             <Col sm=2>

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -871,7 +871,8 @@ class ProjectStore extends Store
     get_directory_listings: =>
         return @get('directory_listings')
 
-    get_displayed_listing: =>
+    # search_escape_char may or may not be the right way to escape search
+    get_displayed_listing : (search_escape_char) =>
         # cached pre-processed file listing, which should always be up to date when called, and properly
         # depends on dependencies.
         # TODO: optimize -- use immutable js and cache result if things haven't changed. (like shouldComponentUpdate)
@@ -903,7 +904,7 @@ class ProjectStore extends Store
             @_compute_snapshot_display_names(listing)
 
         search = @get('file_search')?.toLowerCase()
-        if search
+        if search and search[0] isnt search_escape_char
             listing = @_matched_files(search, listing)
 
         map = {}


### PR DESCRIPTION
Staging here: https://cloud.sagemath.com/7552f6e3-0f4f-4476-8954-38b9f14c6069/port/57488/

No UI changes occur except to show output and to warn user.

To use, begin a search with `/` followed by a miniterm command.