### PR TITLE
[MAJOR BUG!] create project without upgrades

### DIFF
--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1067,7 +1067,7 @@ NewProjectCreator = rclass
                         <Button
                             disabled = {@state.title_text == '' or @state.state == 'saving'}
                             bsStyle  = 'success'
-                            onClick  = {@create_project} >
+                            onClick  = {=>@create_project(false)} >
                             Create project without upgrades
                         </Button>
                         <Button


### PR DESCRIPTION
I just created a new project and clicked "Create Project Without Upgrades".  This **still** applied the members only and networking upgrades.  This makes absolutely no sense (i.e., it is a clear bug).  Please fix. 