### PR TITLE
Attach import repl fix

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3180,42 +3180,52 @@ def load_html_resource(filename):
     elif ext == "js":
         salvus.html('<script src="%s"></script>'%url)
 
-def attach(*args):
-    r"""
-    Load file(s) into the Sage worksheet process and add to list of attached files.
-    All attached files that have changed since they were last loaded are reloaded
-    the next time a worksheet cell is executed.
+try:
+    from sage.repl.attach import load_attach_path, modified_file_iterator
+    def attach(*args):
+        r"""
+        Load file(s) into the Sage worksheet process and add to list of attached files.
+        All attached files that have changed since they were last loaded are reloaded
+        the next time a worksheet cell is executed.
 
-    INPUT:
+        INPUT:
 
-    - ``files`` - list of strings, filenames to attach
+        - ``files`` - list of strings, filenames to attach
 
-    .. SEEALSO::
+        .. SEEALSO::
 
-        :meth:`sage.repl.attach.attach` docstring has details on how attached files
-        are handled
-    """
-    # can't (yet) pass "attach = True" to load(), so do this
+            :meth:`sage.repl.attach.attach` docstring has details on how attached files
+            are handled
+        """
+        # can't (yet) pass "attach = True" to load(), so do this
 
-    import sage.repl.attach
+        from sage_server import attach_available
 
-    if len(args) == 1:
-        if isinstance(args[0], (unicode,str)):
-            args = tuple(args[0].replace(',',' ').split())
-        if isinstance(args[0], (list, tuple)):
-            args = args[0]
+        if not attach_available():
+            print("attach not available")
+            return
 
-    from sage.repl.attach import load_attach_path
-    for fname in args:
-        for path in load_attach_path():
-            fpath = os.path.join(path, fname)
-            fpath = os.path.expanduser(fpath)
-            if os.path.isfile(fpath):
-                load(fname)
-                sage.repl.attach.add_attached_file(fpath)
-                break
-        else:
-            raise IOError('did not find file %r to attach' % fname)
+        if len(args) == 1:
+            if isinstance(args[0], (unicode,str)):
+                args = tuple(args[0].replace(',',' ').split())
+            if isinstance(args[0], (list, tuple)):
+                args = args[0]
+
+        for fname in args:
+            for path in load_attach_path():
+                fpath = os.path.join(path, fname)
+                fpath = os.path.expanduser(fpath)
+                if os.path.isfile(fpath):
+                    load(fname)
+                    sage.repl.attach.add_attached_file(fpath)
+                    break
+            else:
+                raise IOError('did not find file %r to attach' % fname)
+except ImportError:
+    print("sage_salvus: attach not available")
+    def attach(*args):
+        print("attach not available")
+
 
 # Monkey-patched the load command
 def load(*args, **kwds):

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3218,7 +3218,7 @@ try:
 except ImportError:
     print("sage_salvus: attach not available")
     def attach(*args):
-        sys.stderr.write("attach not available\n")
+        sys.stderr.write("Error: The 'attach' functionality is not available.\n")
         sys.stderr.flush()
 
 

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3199,10 +3199,6 @@ try:
         """
         # can't (yet) pass "attach = True" to load(), so do this
 
-        if not attach_available():
-            print("attach not available")
-            return
-
         if len(args) == 1:
             if isinstance(args[0], (unicode,str)):
                 args = tuple(args[0].replace(',',' ').split())

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3199,8 +3199,6 @@ try:
         """
         # can't (yet) pass "attach = True" to load(), so do this
 
-        from sage_server import attach_available
-
         if not attach_available():
             print("attach not available")
             return

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3218,7 +3218,8 @@ try:
 except ImportError:
     print("sage_salvus: attach not available")
     def attach(*args):
-        print("attach not available")
+        sys.stderr.write("attach not available\n")
+        sys.stderr.flush()
 
 
 # Monkey-patched the load command

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -65,8 +65,6 @@ try:
             print('### reloading attached file {0} modified at {1} ###'.format(basename, timestr))
             from sage_salvus import load
             load(filename)
-    def attach_available():
-        return True
 except:
     print("sage_server: attach not available")
     def reload_attached_files_if_mod_smc():

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -56,7 +56,7 @@ import sage_parsing, sage_salvus
 uuid = sage_salvus.uuid
 
 try:
-    from sage.repl.attach import modified_file_iterator
+    from sage.repl.attach import load_attach_path, modified_file_iterator
     def reload_attached_files_if_mod_smc():
         # see sage/src/sage/repl/attach.py reload_attached_files_if_modified()
         for filename, mtime in modified_file_iterator():
@@ -65,11 +65,12 @@ try:
             print('### reloading attached file {0} modified at {1} ###'.format(basename, timestr))
             from sage_salvus import load
             load(filename)
+    def attach_available():
+        return True
 except:
-    print("attach not available")
+    print("sage_server: attach not available")
     def reload_attached_files_if_mod_smc():
         pass
-
 
 def unicode8(s):
     # I evidently don't understand Python unicode...  Do the following for now:


### PR DESCRIPTION
- wrap second import from sage.repl.attach, in sage_salvus.py with try/except

- if either import from sage.repl.attach fails, change attach() function to print warning to worksheet stderr; the import exception messages only go to sage_server.log