### PR TITLE
[ready for review] monkey patch save - upstream #2

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3225,14 +3225,20 @@ except ImportError:
 # Monkey-patch the save command
 def save(obj, filename=None, compress=True, **kwds):
     """
-    Workaround save() of function or class loaded or defined at top level in worksheet: put object into __main__ module.
+    Save ``obj`` to the file with name ``filename``.
 
-    Limitations:
+    .. NOTE::
 
-    XXX Does not fix the problem if pickle.dumps() is called instead of save()
+        sage_salvus.save() is a workaround to allow saving a function or class
+        loaded or defined at top level
 
-    XXX Docstring is incomplete pending review of PR
+    .. WARNING::
 
+        Not applicable if pickle.dumps() is called instead of save()
+
+    .. SEEALSO::
+
+        :func:`sage_object.save`
     """
     objmod = getattr(obj, '__module__', None)
     if objmod is None or getattr(obj, '__module__', None) == '__builtin__':

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3225,20 +3225,10 @@ except ImportError:
 # Monkey-patch the save command
 def save(obj, filename=None, compress=True, **kwds):
     """
-    Save ``obj`` to the file with name ``filename``.
-
     .. NOTE::
 
         sage_salvus.save() is a workaround to allow saving a function or class
-        loaded or defined at top level
-
-    .. WARNING::
-
-        Not applicable if pickle.dumps() is called instead of save()
-
-    .. SEEALSO::
-
-        :func:`sage_object.save`
+        loaded or defined at top level.
     """
     objmod = getattr(obj, '__module__', None)
     if objmod is None or getattr(obj, '__module__', None) == '__builtin__':
@@ -3248,6 +3238,8 @@ def save(obj, filename=None, compress=True, **kwds):
             smm = sys.modules['__main__']
             setattr(smm, obj.__name__, obj)
             sage.structure.sage_object.save(obj, filename=filename, compress=compress, **kwds)
+
+save.__doc__ = sage.structure.sage_object.save.__doc__ + save.__doc__
 
 # Monkey-patched the load command
 def load(*args, **kwds):

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3222,6 +3222,27 @@ except ImportError:
         sys.stderr.flush()
 
 
+# Monkey-patch the save command
+def save(obj, filename=None, compress=True, **kwds):
+    """
+    Workaround save() of function or class loaded or defined at top level in worksheet: put object into __main__ module.
+
+    Limitations:
+
+    XXX Does not fix the problem if pickle.dumps() is called instead of save()
+
+    XXX Docstring is incomplete pending review of PR
+
+    """
+    objmod = getattr(obj, '__module__', None)
+    if objmod is None or getattr(obj, '__module__', None) == '__builtin__':
+        smb = sys.modules['__builtin__']
+        if not obj.__name__ in dir(smb):
+            setattr(obj, '__module__', '__main__')
+            smm = sys.modules['__main__']
+            setattr(smm, obj.__name__, obj)
+            sage.structure.sage_object.save(obj, filename=filename, compress=compress, **kwds)
+
 # Monkey-patched the load command
 def load(*args, **kwds):
     """

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1757,7 +1757,7 @@ def serve(port, host, extra_imports=False):
 
         for name in ['coffeescript', 'javascript', 'time', 'timeit', 'capture', 'cython',
                      'script', 'python', 'python3', 'perl', 'ruby', 'sh', 'prun', 'show', 'auto',
-                     'hide', 'hideall', 'cell', 'fork', 'exercise', 'dynamic', 'var','jupyter',
+                     'hide', 'hideall', 'cell', 'fork', 'exercise', 'dynamic', 'var', 'jupyter', 'save',
                      'reset', 'restore', 'md', 'load', 'attach', 'runfile', 'typeset_mode', 'default_mode',
                      'sage_chat', 'fortran', 'magics', 'go', 'julia', 'pandoc', 'wiki', 'plot3d_using_matplotlib',
                      'mediawiki', 'help', 'raw_input', 'clear', 'delete_last_output', 'sage_eval']:


### PR DESCRIPTION
Upstream issue is [#2](https://github.com/sagemathinc/smc/issues/2)

Please review. Not sure this is the best way to deal with problem:
- Is it ok to insert functions and classes into `__main__`?
- Problem still occurs if user calls pickle or cPickle dump methods directly.

Test worksheet here:
https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/SAGEWS/issue0002.sagews

Parent module of worksheet appears to be `__builtin__`, but defined functions and classes at top level do not show up in namespace for `__builtin__`. Problem notes here:
https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/SAGEWS/issue0002.md