### PR TITLE
introspection fix for #295

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_parsing.py
+++ b/src/smc_sagews/smc_sagews/sage_parsing.py
@@ -346,7 +346,7 @@ def introspect(code, namespace, preparse=True):
         expr        = code0[i:]%literals
         before_expr = code0[:i]%literals
 
-        chrs = set('.()[]?')
+        chrs = set('.()[]? ')
         if not any(c in expr for c in chrs):
             # Easy case: this is just completion on a simple identifier in the namespace.
             get_help = False; get_completions = True; get_source = False


### PR DESCRIPTION
Fixes these two cases from #295 in sage worksheet:
```
abc = [1,2,3]
-- new cell --
for a in ab[tab]
3 * ab[tab]
```
These examples have been added to test file for #701 at https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/SAGEWS/issue701.sagews - all tests pass