### PR TITLE
Sjmode upstream #722

### DIFF
--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -1021,10 +1021,10 @@ exports.commands =
                          f(x) = b * x + sin(a * x)
                          plot(f, (x, -5, 5)).show()
                      """
-        magics:
-            insert : "magics()"
+        modes:
+            insert : "print('\\n'.join(modes()))"
         jupyterkernels:
-            insert : "%jupyter.available_kernels"
+            insert : "print(jupyter.available_kernels())"
         mode_typeset:
             insert : "%typeset_mode True"
         mode_auto:
@@ -1504,7 +1504,7 @@ initialize_sage_python_r_toolbar = () ->
             ["HTML", "#mode_html"],
             ["Javascript", "#mode_javascript"],
             ["Julia", "#mode_julia"],
-            ["Jupyter Bridge", "#mode_jupyter_bridge"],
+            ["Jupyter bridge", "#mode_jupyter_bridge"],
             ["Markdown", "#mode_md"],
             ["Python", "#mode_python"],
             ["R", "#mode_r"],
@@ -1515,7 +1515,7 @@ initialize_sage_python_r_toolbar = () ->
     help_list = ["<i class='fa fa-question-circle'></i> Help", "Sage Worksheet Help",
         [
             ["General help", "#help"],
-            ["Magic mode commands", "#magics"],
+            ["Mode commands", "#modes"],
             ["Jupyter kernels", "#jupyterkernels"],
             ["SageMath Documentation"],
             ["Overview", "#sagemathdoc"],

--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -1023,6 +1023,8 @@ exports.commands =
                      """
         magics:
             insert : "magics()"
+        jupyterkernels:
+            insert : "%jupyter.available_kernels"
         mode_typeset:
             insert : "%typeset_mode True"
         mode_auto:
@@ -1045,6 +1047,12 @@ exports.commands =
             insert : "%julia"
         mode_javascript:
             insert : "%javascript\n/* Use print(...) for output */"
+        mode_jupyter_bridge:
+            insert : """
+                    a3 = jupyter("anaconda3")
+                    # start new cells with %a3
+                    # or set %default_mode a3
+                     """
         mode_md:
             insert : "%md"
         mode_python:
@@ -1496,6 +1504,7 @@ initialize_sage_python_r_toolbar = () ->
             ["HTML", "#mode_html"],
             ["Javascript", "#mode_javascript"],
             ["Julia", "#mode_julia"],
+            ["Jupyter Bridge", "#mode_jupyter_bridge"],
             ["Markdown", "#mode_md"],
             ["Python", "#mode_python"],
             ["R", "#mode_r"],
@@ -1507,6 +1516,7 @@ initialize_sage_python_r_toolbar = () ->
         [
             ["General help", "#help"],
             ["Magic mode commands", "#magics"],
+            ["Jupyter kernels", "#jupyterkernels"],
             ["SageMath Documentation"],
             ["Overview", "#sagemathdoc"],
             ["Tutorial", "#sagemathtutorial"],

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3505,22 +3505,22 @@ def modes():
     a string as input and outputs a string. (Yes, it is that simple.)
     """
     import re
-    magic_cmds = set()
+    mode_cmds = set()
     for s in open(os.path.realpath(__file__), 'r').xreadlines():
         s = s.strip()
         if s.startswith('%'):
-            magic_cmds.add(re.findall(r'%[a-zA-Z]+', s)[0])
-    magic_cmds.discard('%s')
+            mode_cmds.add(re.findall(r'%[a-zA-Z]+', s)[0])
+    mode_cmds.discard('%s')
     for k,v in sage.interfaces.all.__dict__.iteritems():
         if isinstance(v, sage.interfaces.expect.Expect):
-            magic_cmds.add('%'+k)
-    magic_cmds.update(['%cython', '%time', '%auto', '%hide', '%hideall',
+            mode_cmds.add('%'+k)
+    mode_cmds.update(['%cython', '%time', '%auto', '%hide', '%hideall',
                        '%fork', '%runfile', '%default_mode', '%typeset_mode'])
-    v = list(sorted(magic_cmds))
+    v = list(sorted(mode_cmds))
     return v
 
 ########################################################
-# Go magic
+# Go mode
 ########################################################
 def go(s):
     """

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3488,14 +3488,11 @@ def sage_chat(chatroom=None, height="258px"):
 
 
 ########################################################
-# Documentation of magics
+# Documentation of modes
 ########################################################
-def magics(dummy=None):
+def modes():
     """
-    Type %magics to print all SageMathCloud magic commands or
-    magics() to get a list of them.
-
-    To use a magic command, either type
+    To use a mode command, either type
 
         %command <a line of code>
 
@@ -3504,7 +3501,7 @@ def magics(dummy=None):
         %command
         [rest of cell]
 
-    Create your own magic command by defining a function that takes
+    Create your own mode command by defining a function that takes
     a string as input and outputs a string. (Yes, it is that simple.)
     """
     import re
@@ -3517,14 +3514,10 @@ def magics(dummy=None):
     for k,v in sage.interfaces.all.__dict__.iteritems():
         if isinstance(v, sage.interfaces.expect.Expect):
             magic_cmds.add('%'+k)
-    magic_cmds.update(['%cython', '%time', '%magics', '%auto', '%hide', '%hideall',
+    magic_cmds.update(['%cython', '%time', '%auto', '%hide', '%hideall',
                        '%fork', '%runfile', '%default_mode', '%typeset_mode'])
     v = list(sorted(magic_cmds))
-    if dummy is None:
-        return v
-    else:
-        for s in v:
-            print(s)
+    return v
 
 ########################################################
 # Go magic

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1759,7 +1759,7 @@ def serve(port, host, extra_imports=False):
                      'script', 'python', 'python3', 'perl', 'ruby', 'sh', 'prun', 'show', 'auto',
                      'hide', 'hideall', 'cell', 'fork', 'exercise', 'dynamic', 'var','jupyter',
                      'reset', 'restore', 'md', 'load', 'attach', 'runfile', 'typeset_mode', 'default_mode',
-                     'sage_chat', 'fortran', 'magics', 'go', 'julia', 'pandoc', 'wiki', 'plot3d_using_matplotlib',
+                     'sage_chat', 'fortran', 'modes', 'go', 'julia', 'pandoc', 'wiki', 'plot3d_using_matplotlib',
                      'mediawiki', 'help', 'raw_input', 'clear', 'delete_last_output', 'sage_eval']:
             namespace[name] = getattr(sage_salvus, name)
 


### PR DESCRIPTION
Ref #722.

sage worksheet buttonbar:
- **Help > Magic mode commands** renamed to **Help > Mode commands** and inserts `print('\n'.join(modes()))`
- **Help > Jupyter kernels** inserts `print(jupyter.available_kernels())`
- **Modes > Jupyter bridge** inserts
```
a3 = jupyter("anaconda3")
# start new cells with %a3
 # or set %default_mode a3
```
sage worksheet inline:
- get rid of the dummy argument to the magics function, so %magics doesn’t work
- make it modes rather than magics