### PR TITLE
[ready for review] allow tab completion on glob expressions upstream #734

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -757,13 +757,21 @@ exports.define_codemirror_extensions = () ->
             that.replaceRange(str, from, to)
 
         if completions.length == 1
-            insert(target + completions[0])
+            # do not include target in appended completion if it has a '*'
+            if target.indexOf('*') == -1
+                insert(target + completions[0])
+            else
+                insert(completions[0])
             return
 
         sel = $("<select>").css('width','auto')
         complete = $("<div>").addClass("salvus-completions").append(sel)
         for c in completions
-            sel.append($("<option>").text(target + c))
+            # do not include target in appended completion if it has a '*'
+            if target.indexOf('*') == -1
+                sel.append($("<option>").text(target + c))
+            else
+                sel.append($("<option>").text(c))
         sel.find(":first").attr("selected", true)
         sel.attr("size", Math.min(completions_size, completions.length))
         pos = @cursorCoords(from)


### PR DESCRIPTION
Reference #734.

The following now allow tab completion:
- `*_factors[tab]`
- `*le_pr*[tab]`
- `list.re*e[tab]`

There is a test file at https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/tabs734.sagews, but misc_page.coffee as well as sage_parsing.py will need to be updated for examples to work.

This follows the precedent in command-line sage in which a get-completions expression is treated as a wildcard expression if it contains one or more embedded asterisks. See [IPython/core/inputtransformer.py](https://github.com/ipython/ipython/blob/8b766e65c15d3f07e05ee6228d60256a5451df0d/IPython/core/inputtransformer.py#L211)