### PR TITLE
[needs work] The cookie set should be a wildcard cookie so if log in via sage.cocalc would be authed if go to cocalc.com or python.cocalc etc

### DIFF
--- a/src/smc-hub/auth.coffee
+++ b/src/smc-hub/auth.coffee
@@ -221,7 +221,13 @@ passport_login = (opts) ->
             dbg("set remember_me cookies in client")
             expires = new Date(new Date().getTime() + ttl*1000)
             cookies = new Cookies(opts.req, opts.res)
-            cookies.set(BASE_URL + 'remember_me', remember_me_value, {expires:expires})
+            root_domain = window.location.hostname
+            # We are setting a wildcard cookie so one can login at sage.cocalc.com and
+            # be logged in automatically when go to cocalc.com
+            # We assume simple tlds like .com, .net, .org
+            root_domain = window.location.hostname.split('.')
+            root_domain = '.'+root_domain[-2]+'.'+root_domain[-1]
+            cookies.set(root_domain + 'remember_me', remember_me_value, {expires:expires})
             dbg("set remember_me cookie in database")
             opts.database.save_remember_me
                 account_id : account_id


### PR DESCRIPTION
According to http://serverfault.com/questions/153409/can-subdomain-example-com-set-a-cookie-that-can-be-read-by-example-com looks like one puts a . in front of domain