### PR TITLE
webapp: preventing accidental file drops outside the drop area

### DIFF
--- a/src/smc-webapp/last.coffee
+++ b/src/smc-webapp/last.coffee
@@ -111,3 +111,11 @@ $ ->
         MathJax.Hub?.Queue([mathjax_finish_startup])
     document.getElementsByTagName("head")[0].appendChild(mjscript)
 
+    # register a default drag and drop handler, that prevents accidental file drops
+    # therefore, dropping files only works when done right above the dedicated dropzone
+    $(document).on 'dragover', (e) ->
+        e.preventDefault()
+    $(document).on 'drop', (e) ->
+        e.preventDefault()
+        {alert_message} = require('./alerts')
+        alert_message(type:'info', message: 'To upload a file, drop it into the "Drop files to upload" area!')


### PR DESCRIPTION
This is related to #61 and will still be there when the file area is a dropzone -- with a different info text, of course.