### PR TITLE
The warning, when searching for projects, is not large/bold enough.

### DIFF
--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1257,6 +1257,10 @@ ProjectsListingDescription = rclass
             desc = "Only showing #{n} #{d}#{a}#{h} #{misc.plural(n, 'project')}"
             <h3 style={color:'#666', wordWrap:'break-word'}>{desc}</h3>
 
+    clear_and_focus_input : ->
+        redux.getActions('projects').setState(search: '')
+        @refs.projects_search.getInputDOMNode().focus()
+
     render_span : (query) ->
         <span>whose title, description or users contain <strong>{query}</strong>
         <Space/><Space/>

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1257,6 +1257,13 @@ ProjectsListingDescription = rclass
             desc = "Only showing #{n} #{d}#{a}#{h} #{misc.plural(n, 'project')}"
             <h3 style={color:'#666', wordWrap:'break-word'}>{desc}</h3>
 
+    render_span : (query) ->
+        <span>whose title, description or users contain <strong>{query}</strong>
+        <Space/><Space/>
+        <Button onClick={@clear_and_focus_input}>
+            CLEAR SEARCH
+        </Button></span>
+
     render_alert_message : ->
         query = @props.search.toLowerCase()
         hashtags_string = (name for name of @props.selected_hashtags).join(' ')
@@ -1264,11 +1271,11 @@ ProjectsListingDescription = rclass
         query += hashtags_string
 
         if query isnt '' or @props.deleted or @props.hidden
-            <Alert bsStyle='warning'>
+            <Alert bsStyle='warning' style={'fontSize':'1.2em'}>
                 Only showing<Space/>
                 <strong>{"#{if @props.deleted then 'deleted ' else ''}#{if @props.hidden then 'hidden ' else ''}"}</strong>
                 projects<Space/>
-                {if query isnt '' then <span>whose title, description or users contain <strong>{query}</strong></span>}
+                {if query isnt '' then @render_span(query)}
             </Alert>
 
     render : ->


### PR DESCRIPTION
If you go into the list of projects, and begin to search for something that is not found in any project of the descriptions, the system correctly displays none of your projects.

However, the warning is not very large and not very bold. This might panic a user, who incorrectly imagines that their projects have all vanished. In fact, this very thing happened on August 4th, at MathFest 2016, to James Quinlan of the University of New England, and it panicked him visibly. 

This talk was essentially a demo of SageMathCloud, and it left the impression that SageMathCloud is non-trivial to use---precisely the antithesis of the talk's objective and purpose.

p.s. This issue ticket was requested by William on August 8th, in an email.