### PR TITLE
[ready for review] allow sage.repl.interpreter._do_preparse to override preparse argument

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -929,10 +929,18 @@ class Salvus(object):
         #code   = sage_parsing.strip_leading_prompts(code)  # broken -- wrong on "def foo(x):\n   print(x)"
         blocks = sage_parsing.divide_into_blocks(code)
 
-        import sage.repl.interpreter
+        try:
+            import sage.repl.interpreter as sage_repl_interpreter
+        except:
+            log("Error - unable to import sage.repl.interpreter")
 
         for start, stop, block in blocks:
-            if preparse and sage.repl.interpreter._do_preparse:
+            # if import sage.repl.interpreter fails, sag_repl_interpreter is unreferenced
+            try:
+                do_pp = getattr(sage_repl_interpreter, '_do_preparse', True)
+            except:
+                do_pp = True
+            if preparse and do_pp:
                 block = sage_parsing.preparse_code(block)
             sys.stdout.reset(); sys.stderr.reset()
             try:

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -929,8 +929,10 @@ class Salvus(object):
         #code   = sage_parsing.strip_leading_prompts(code)  # broken -- wrong on "def foo(x):\n   print(x)"
         blocks = sage_parsing.divide_into_blocks(code)
 
+        import sage.repl.interpreter
+
         for start, stop, block in blocks:
-            if preparse:
+            if preparse and sage.repl.interpreter._do_preparse:
                 block = sage_parsing.preparse_code(block)
             sys.stdout.reset(); sys.stderr.reset()
             try:


### PR DESCRIPTION
Proposed fix for #399 is to override `Salvus.execute()` argument `preparse` if `preparser(False)` has been called.

Test cases are in https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/SAGEWS/issue399test.sagews. That project is running the proposed modification.
