### PR TITLE
[ready for review] Issue757 license() for sagews

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3615,3 +3615,17 @@ def help(*args, **kwds):
 
 # Import the jupyter kernel client.
 from sage_jupyter import jupyter
+
+# license() workaround for IPython pager
+# could also set os.environ['TERM'] to 'dumb' to workaround the pager
+def license():
+    r"""
+    Display Sage license file COPYING.txt
+ 
+    You can also view this information in an SMC terminal session:
+ 
+        | $ sage
+        | sage: license()
+ 
+    """
+    print(sage.misc.copying.license)

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1760,7 +1760,8 @@ def serve(port, host, extra_imports=False):
                      'hide', 'hideall', 'cell', 'fork', 'exercise', 'dynamic', 'var','jupyter',
                      'reset', 'restore', 'md', 'load', 'attach', 'runfile', 'typeset_mode', 'default_mode',
                      'sage_chat', 'fortran', 'modes', 'go', 'julia', 'pandoc', 'wiki', 'plot3d_using_matplotlib',
-                     'mediawiki', 'help', 'raw_input', 'clear', 'delete_last_output', 'sage_eval']:
+                     'mediawiki', 'help', 'raw_input', 'clear', 'delete_last_output', 'sage_eval',
+                     'license']:
             namespace[name] = getattr(sage_salvus, name)
 
         namespace['sage_server'] = sys.modules[__name__]    # http://stackoverflow.com/questions/1676835/python-how-do-i-get-a-reference-to-a-module-inside-the-module-itself


### PR DESCRIPTION
Ref: #757 

IPython pager did not sent output to BufferedOutputStream, even after adding encoding attribute, unless TERM environment variable was temporarily set to 'dumb'. Instead of going doing that, here's another monkey patch.

Note: With default limits, calling license() from sagews truncates output with error message  
_WARNING: Output: 70068 truncated by MAX_STDOUT_SIZE to 40000.  Type 'smc?' to learn how to raise the output limit._  

Rather than modifying limits, I added a reminder in the docstring that the sage `license()` command (which invokes a pager) is available in a terminal session.