### PR TITLE
[ready for review] issue819 block parser skip comments

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_parsing.py
+++ b/src/smc_sagews/smc_sagews/sage_parsing.py
@@ -73,11 +73,12 @@ def strip_string_literals(code, state=None):
             # it's a comment
             newline = code.find('\n', hash_q)
             if newline == -1: newline = len(code)
-            counter += 1
-            label = "L%s" % counter
-            literals[label] = code[hash_q:newline]   # changed from sage
+            # skip string substitution for comments from # to eol
+            # counter += 1
+            # label = "L%s" % counter
+            # literals[label] = code[hash_q:newline]   # changed from sage
             new_code.append(code[start:hash_q].replace('%','%%'))
-            new_code.append("%%(%s)s" % label)
+            # new_code.append("%%(%s)s" % label)
             start = q = newline
         elif q == -1:
             if in_quote:
@@ -223,6 +224,7 @@ def divide_into_blocks(code):
                 brack_depth += code[i].count('[') - code[i].count(']')
                 curly_depth += code[i].count('{') - code[i].count('}')
         # remove comments
+        # comments now removed in strip_string_literals() but leaving this in place
         for k, v in literals.iteritems():
             if v.startswith('#'):
                 literals[k] = ''


### PR DESCRIPTION
Ref #819 

Block parser was substituting comments (as well as strings) with %(Lxx) labels and removing them later. Code that substituted the comments is taken out.

Internal testing at https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/SAGEWS/issue819test.sagews - requires code change to be in place. 