### PR TITLE
Remember all tabs when refreshing

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1075,13 +1075,13 @@ class exports.Editor
             if @open_file_tabs().length < 1
                 @resize_open_file_tabs()
 
-            if (!(window.localStorage.getItem("opened_files")))
-                window.localStorage.setItem("opened_files", "[]")
-            opened_files = JSON.parse(window.localStorage.getItem("opened_files"))
+            if (!(window.localStorage["opened_files"]))
+                window.localStorage["opened_files"] =  "[]"
+            opened_files = JSON.parse(window.localStorage["opened_files"])
             for value, index in opened_files
                 if value['project_id'] == @project_id and value['path'] == filename
                     opened_files.splice(index, 1)
-            window.localStorage.setItem("opened_files", JSON.stringify(opened_files))
+            window.localStorage["opened_files"] = JSON.stringify(opened_files)
 
             return false
 

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1078,9 +1078,7 @@ class exports.Editor
             if (!(window.localStorage["opened_files"]))
                 window.localStorage["opened_files"] =  "[]"
             opened_files = JSON.parse(window.localStorage["opened_files"])
-            for value, index in opened_files
-                if value['project_id'] == @project_id and value['path'] == filename
-                    opened_files.splice(index, 1)
+            delete opened_files[@project_id+'-'+filename]
             window.localStorage["opened_files"] = JSON.stringify(opened_files)
 
             return false

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1075,6 +1075,14 @@ class exports.Editor
             if @open_file_tabs().length < 1
                 @resize_open_file_tabs()
 
+            if (!(window.localStorage.getItem("opened_files")))
+                window.localStorage.setItem("opened_files", "[]")
+            opened_files = JSON.parse(window.localStorage.getItem("opened_files"))
+            for value, index in opened_files
+                if value['project_id'] == @project_id and value['path'] == filename
+                    opened_files.splice(index, 1)
+            window.localStorage.setItem("opened_files", JSON.stringify(opened_files))
+
             return false
 
         link.find(".salvus-editor-close-button-x").click(close_tab)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -196,11 +196,9 @@ class ProjectActions extends Actions
                                 @set_current_path(misc.path_split(opts.path).head, update_file_listing=false)
         # log file opening to HTML5 storage so we can auto reopen tabs at some point
         if (!(window.localStorage["opened_files"]))
-            window.localStorage["opened_files"] =  "[]"
+            window.localStorage["opened_files"] =  "{}"
         opened_files = JSON.parse(window.localStorage["opened_files"])
-        console.log('opened_files:', window.localStorage["opened_files"])
-        if (!(window.localStorage["opened_files"].indexOf(JSON.stringify({'project_id': @project_id, 'path': opts.path})) > -1))
-            opened_files.push({'project_id': @project_id, 'path': opts.path})
+        opened_files['#{@project_id}-#{path}'] = true
         window.localStorage["opened_files"] = JSON.stringify(opened_files)
         return
 

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -194,6 +194,13 @@ class ProjectActions extends Actions
                                 @_project().show_editor_chat_window(opts.path)
                             if opts.foreground
                                 @set_current_path(misc.path_split(opts.path).head, update_file_listing=false)
+        # log file opening to HTML5 storage so we can auto reopen tabs at some point
+        if (!(window.localStorage.getItem("opened_files")))
+            window.localStorage.setItem("opened_files", "[]")
+        opened_files = JSON.parse(window.localStorage.getItem("opened_files"))
+        console.log('opened_files:', window.localStorage.getItem("opened_files"))
+        if (!(window.localStorage.getItem("opened_files").indexOf(JSON.stringify({'project_id': @project_id, 'path': opts.path})) > -1))
+            opened_files.push({'project_id': @project_id, 'path': opts.path})
         return
 
     foreground_project : =>

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -195,12 +195,13 @@ class ProjectActions extends Actions
                             if opts.foreground
                                 @set_current_path(misc.path_split(opts.path).head, update_file_listing=false)
         # log file opening to HTML5 storage so we can auto reopen tabs at some point
-        if (!(window.localStorage.getItem("opened_files")))
-            window.localStorage.setItem("opened_files", "[]")
-        opened_files = JSON.parse(window.localStorage.getItem("opened_files"))
-        console.log('opened_files:', window.localStorage.getItem("opened_files"))
-        if (!(window.localStorage.getItem("opened_files").indexOf(JSON.stringify({'project_id': @project_id, 'path': opts.path})) > -1))
+        if (!(window.localStorage["opened_files"]))
+            window.localStorage["opened_files"] =  "[]"
+        opened_files = JSON.parse(window.localStorage["opened_files"])
+        console.log('opened_files:', window.localStorage["opened_files"])
+        if (!(window.localStorage["opened_files"].indexOf(JSON.stringify({'project_id': @project_id, 'path': opts.path})) > -1))
             opened_files.push({'project_id': @project_id, 'path': opts.path})
+        window.localStorage["opened_files"] = JSON.stringify(opened_files)
         return
 
     foreground_project : =>

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -198,7 +198,7 @@ class ProjectActions extends Actions
         if (!(window.localStorage["opened_files"]))
             window.localStorage["opened_files"] =  "{}"
         opened_files = JSON.parse(window.localStorage["opened_files"])
-        opened_files['#{@project_id}-#{path}'] = true
+        opened_files[@project_id+'-'+opts.path] = true
         window.localStorage["opened_files"] = JSON.stringify(opened_files)
         return
 

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -47,15 +47,15 @@ MAX_DEFAULT_PROJECTS = 50
 _create_project_tokens = {}
 window.smc.restore_tabs = () ->
     if (!(window.localStorage["opened_files"]))
-        window.localStorage["opened_files"] = "[]"
+        window.localStorage["opened_files"] = "{}"
     opened_files = JSON.parse(window.localStorage["opened_files"])
-    for tab in opened_files
-        redux.getProjectActions(tab['project_id']).open_file
-            path       : tab['path']
+    for tab in Object.keys(opened_files)
+        redux.getProjectActions(tab.slice(0,36)).open_file
+            path       : tab.slice(37)
             foreground : false
 
 window.smc.reset_tabs = () ->
-    window.localStorage["opened_files"] = "[]"
+    window.localStorage["opened_files"] = "{}"
 
 # Define projects actions
 class ProjectsActions extends Actions

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -46,6 +46,17 @@ MAX_DEFAULT_PROJECTS = 50
 
 _create_project_tokens = {}
 
+window.restore_tabs = () ->
+    if (!(window.localStorage.getItem("opened_files")))
+        window.localStorage.setItem("opened_files", "[]")
+    opened_files = JSON.parse(window.localStorage.getItem("opened_files"))
+    for tab in opened_files
+        redux.getProjectActions(tab['project_id']).open_file
+            path : tab['path']
+
+window.reset_tabs = () ->
+    window.localStorage.setItem("opened_files", "[]")
+
 # Define projects actions
 class ProjectsActions extends Actions
     # Local state events

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -51,7 +51,8 @@ window.smc.restore_tabs = () ->
     opened_files = JSON.parse(window.localStorage["opened_files"])
     for tab in opened_files
         redux.getProjectActions(tab['project_id']).open_file
-            path : tab['path']
+            path       : tab['path']
+            foreground : false
 
 window.smc.reset_tabs = () ->
     window.localStorage["opened_files"] = "[]"

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -45,17 +45,16 @@ markdown = require('./markdown')
 MAX_DEFAULT_PROJECTS = 50
 
 _create_project_tokens = {}
-
-window.restore_tabs = () ->
-    if (!(window.localStorage.getItem("opened_files")))
-        window.localStorage.setItem("opened_files", "[]")
-    opened_files = JSON.parse(window.localStorage.getItem("opened_files"))
+window.smc.restore_tabs = () ->
+    if (!(window.localStorage["opened_files"]))
+        window.localStorage["opened_files"] = "[]"
+    opened_files = JSON.parse(window.localStorage["opened_files"])
     for tab in opened_files
         redux.getProjectActions(tab['project_id']).open_file
             path : tab['path']
 
-window.reset_tabs = () ->
-    window.localStorage.setItem("opened_files", "[]")
+window.smc.reset_tabs = () ->
+    window.localStorage["opened_files"] = "[]"
 
 # Define projects actions
 class ProjectsActions extends Actions


### PR DESCRIPTION
Whenever there's a new version of SMC, I am asked to do a 'hard' refresh. Once SMC restarts, it is kind enough to remember the project and file I was working on, but totally forgets all other files and projects. I would like to have it remember everything that is open. Thanks.
