### PR TITLE
webapp/console: fixing col width and more room for line height

### DIFF
--- a/src/smc-webapp/_console.sass
+++ b/src/smc-webapp/_console.sass
@@ -40,8 +40,7 @@
 
 .salvus-console-terminal
   font-family: droid-sans-mono
-  /* really set in console.coffee, overriding this! */
-  padding: 1ex
+  padding: 1px
   margin: 0px
   white-space: nowrap
   /* critical at least for firefox and IE */

--- a/src/smc-webapp/console.coffee
+++ b/src/smc-webapp/console.coffee
@@ -120,7 +120,7 @@ class Console extends EventEmitter
             font        :   # only for 'ttyjs' renderer
                 family : undefined
                 size   : undefined                           # CSS font-size in points
-                line_height : 115                            # CSS line-height percentage
+                line_height : 120                            # CSS line-height percentage
 
             highlight_mode : 'none'
             renderer       : 'ttyjs'   # options -- 'auto' (best for device); 'codemirror' (mobile support--useless), 'ttyjs' (xterm-color!)
@@ -873,10 +873,10 @@ class Console extends EventEmitter
         # DOM programming...
 
         # Determine size of container DOM.
-        # Determine the average width of a character by inserting 10 blank spaces,
+        # Determine the average width of a character by inserting 10 characters,
         # seeing how wide that is, and dividing by 10.  The result is typically not
         # an integer, which is why we have to use multiple characters.
-        @_c = $("<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>").prependTo(@terminal.element)
+        @_c = $("<span>Term-inal&nbsp;</span>").prependTo(@terminal.element)
 
         # We have to do the actual calculation in the next render loop, since otherwise the terminal
         # might not yet have resized, or the text we just inserted might not yet be visible.
@@ -907,10 +907,10 @@ class Console extends EventEmitter
 
         # Determine the number of columns from the width of a character, computed above.
         font_size = @opts.font.size
-        new_cols = Math.max(1,Math.floor(elt.width() / character_width))
+        new_cols = Math.max(1, Math.floor(elt.width() / character_width))
 
-        # Determine number of rows from the height of the row , as computed above.
-        new_rows = Math.max(1,Math.floor((elt.height()-10) / row_height))
+        # Determine number of rows from the height of the row, as computed above.
+        new_rows = Math.max(1, Math.floor((elt.height() - 10) / row_height))
 
         # Resize the renderer
         @terminal.resize(new_cols, new_rows)


### PR DESCRIPTION
this addresses #860 and also adds a bit of room for lines to avoid overwriting "_" by the next line.

I also bet that this is browser/OS specific, so maybe it always worked for @williamstein but never for me? My hope is, that my fix here errs on the lower side, such that the terminal is in all cases narrower than before.