### PR TITLE
fix mobile chat on android (and iphone chrome)

### DIFF
--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -1025,7 +1025,7 @@ ChatRoom = (name) -> rclass
                 <Row>
                     <Col xs={10} style={padding:'0px 2px 0px 2px'}>
                         <Input
-                            autoFocus   = {false}
+                            autoFocus   = {true}
                             rows        = 2
                             type        = 'textarea'
                             ref         = 'input'


### PR DESCRIPTION
You currently can't type messages into the main chatrooms in SMC on mobile chrome (on iOS / Android).  It works fie on mobile safari.