### PR TITLE
fix search_src after SMC upgrade to sage-7.3

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3671,7 +3671,7 @@ def search_src(str, max_chars = MAX_CODE_SIZE):
     # /projects/sage/sage-x.y/src
     sdir = glob.glob(sdir + "/src/sage")[0]
 
-    cmd = 'cd %s;timeout 5 find . -type f | xargs grep -il "%s" | sed -e "s/..//"'%(sdir, str)
+    cmd = 'cd %s;timeout 5 git grep -il "%s"'%(sdir, str)
     srch = os.popen(cmd).read().splitlines()
     header = "files matched"
     nftext = header + ": %s"%len(srch)

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3662,16 +3662,16 @@ def search_src(str, max_chars = MAX_CODE_SIZE):
     if os.path.islink(sage_cmd):
         sage_cmd = os.readlink(sage_cmd)
 
-    # /projects/sage/sage-6.10/src/bin
+    # /projects/sage/sage-x.y/src/bin
     sdir = os.path.dirname(sage_cmd)
 
-    # /projects/sage/sage-6.10
+    # /projects/sage/sage-x.y
     sdir = os.path.dirname(os.path.dirname(sdir))
 
-    # /projects/sage/sage-6.10/sage-6.10/src
-    sdir = glob.glob(sdir + "/sage-*/src/sage")[0]
+    # /projects/sage/sage-x.y/src
+    sdir = glob.glob(sdir + "/src/sage")[0]
 
-    cmd = 'cd %s;timeout 5 git grep -il "%s"'%(sdir, str)
+    cmd = 'cd %s;timeout 5 find . -type f | xargs grep -il "%s" | sed -e "s/..//"'%(sdir, str)
     srch = os.popen(cmd).read().splitlines()
     header = "files matched"
     nftext = header + ": %s"%len(srch)
@@ -3679,7 +3679,7 @@ def search_src(str, max_chars = MAX_CODE_SIZE):
     @interact
     def _(fname = selector([nftext]+srch,"view source file:")):
         if not fname.startswith(header):
-            with open('/projects/sage/sage/src/sage/' + fname, 'r') as infile:
+            with open(os.path.join(sdir, fname), 'r') as infile:
                 code = infile.read(max_chars)
             salvus.code(code, mode = "python", filename = fname)
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -27,8 +27,9 @@ def test_issue70(exec2):
         pass
     'x'
     """)
-    output = dedent(r"""'x'
-    """)
+    output = dedent(r"""
+    'x'
+    """).lstrip()
     exec2(code, output)
 
 def test_issue819(exec2):
@@ -43,3 +44,9 @@ def test_issue819(exec2):
     output = "22\n"
     exec2(code, output)
 
+class TestSearchSrc:
+    def test_search_src_simple(self, execinteract):
+        execinteract('search_src("convolution")')
+
+    def test_search_src_max_chars(self, execinteract):
+        execinteract('search_src("full cremonadatabase", max_chars = 1000)')

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_x.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_x.py
@@ -1,44 +1,7 @@
 # test_sagews_x.py
 # tests of sage worksheet that return more than stdout, e.g. svg files
-import socket
-import conftest
-import os
-import re
 
-from textwrap import dedent
+def test_plot(execblob):
+    execblob("plot(cos(x),x,0,pi)")
 
-def test_plot(sagews, test_id):
-    SHA_LEN = 36
-    code = "plot(cos(x),x,0,pi)"
-
-    # format and send the plot command
-    m = conftest.message.execute_code(code = code, id = test_id)
-    m['preparse'] = True
-    sagews.send_json(m)
-
-    # send an acknowlegment of the blob to sage_server
-    typ, mesg = sagews.recv()
-    # when a blob is sent, the first 36 bytes are the sha1 uuid
-    assert typ == 'blob'
-    print("blob len %s"%len(mesg))
-    file_uuid = mesg[:SHA_LEN]
-    assert file_uuid == conftest.uuidsha1(mesg[SHA_LEN:])
-
-    # sage_server expects an ack with the right uuid
-    m = conftest.message.save_blob(sha1 = file_uuid)
-    sagews.send_json(m)
-
-    # first json response from sage_server has name of file
-    typ, mesg = sagews.recv()
-    assert typ == 'json'
-    assert 'file' in mesg
-
-    # second json response has html wrapper
-    typ, mesg = sagews.recv()
-    assert typ == 'json'
-    assert 'html' in mesg
-
-    # third json response has done set
-    typ, mesg = sagews.recv()
-    assert typ == 'json'
-    assert mesg['done'] == True
+###


### PR DESCRIPTION
See #898 
~~Use `find|grep`, not `git grep`, for search_src.~~

Fix path for `git grep` command used by search_src. Add pytest cases.