### PR TITLE
sagews %sh mode using jupyter kernel

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -156,6 +156,10 @@ def _jkmagic(kernel_name, **kwargs):
         iopub = kc.iopub_channel
         stdinj = kc.stdin_channel
 
+        # buffering for %capture because we don't know whether output is stdout or stderr
+        # until shell execute_reply messasge is received with status 'ok' or 'error'
+        capture_out = ""
+
         # handle iopub messages
         while True:
             try:
@@ -267,11 +271,15 @@ def _jkmagic(kernel_name, **kwargs):
 
             elif msg_type == 'stream':
                 if 'text' in content:
-                    if 'name' in content and content['name'] == 'stderr':
-                        sys.stderr.write(content['text'])
-                        sys.stderr.flush()
+                    if hasattr(sys.stdout._f, 'im_func'):
+                        if 'name' in content and content['name'] == 'stderr':
+                            sys.stderr.write(content['text'])
+                            sys.stderr.flush()
+                        else:
+                            hout(content['text'],block = False)
                     else:
-                        hout(content['text'],block = False)
+                        # %capture mode
+                        capture_out += content['text'].replace('\r','')
 
             elif msg_type == 'error':
                 # XXX look for ename and evalue too?
@@ -296,15 +304,23 @@ def _jkmagic(kernel_name, **kwargs):
             if msg['parent_header'].get('msg_id') == msg_id:
                 p('shell', msg_type, len(str(content)), str(content)[:300])
                 if msg_type == 'execute_reply':
-                    if content['status'] == 'ok':
-                        if 'payload' in content:
-                            payload = content['payload']
-                            if len(payload) > 0:
-                                if 'data' in payload[0]:
-                                    data = payload[0]['data']
-                                    if 'text/plain' in data:
-                                        text = data['text/plain']
-                                        hout(text, scroll = True)
+                    if hasattr(sys.stdout._f, 'im_func'):
+                        if content['status'] == 'ok':
+                            if 'payload' in content:
+                                payload = content['payload']
+                                if len(payload) > 0:
+                                    if 'data' in payload[0]:
+                                        data = payload[0]['data']
+                                        if 'text/plain' in data:
+                                            text = data['text/plain']
+                                            hout(text, scroll = True)
+                    else:
+                        # %capture mode
+                        if content['status'] == 'ok':
+                            print(capture_out)
+                        elif content['status'] == 'error':
+                            sys.stderr.write(capture_out)
+                            sys.stderr.flush()
                     break
             else:
                 # not our reply

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -1943,10 +1943,10 @@ def fortran(x, library_paths=[], libraries=[], verbose=False):
         if k[0] != '_':
             salvus.namespace[k] = x
 
-
 def sh(code):
     """
-    Run a bash script in Salvus.
+    Run a bash script in Salvus. Uses jupyter bash kernel
+    which allows keeping state between cells.
 
     EXAMPLES:
 
@@ -1971,8 +1971,27 @@ def sh(code):
         %sh pwd
 
     After that, the variable output contains the current directory
+
+    Remember shell state between cells
+
+        %sh
+        FOO='xyz'
+        cd /tmp
+        ... new cell will show settings from previous cell ...
+        %sh
+        echo $FOO
+        pwd
+
+    Display image file (this is a feature of jupyter bash kernel)
+
+        %sh
+        display < sage_logo.png
+
     """
-    return script('/bin/bash')(code)
+    if sh.jupyter_kernel is None:
+        sh.jupyter_kernel = jupyter("bash")
+    return sh.jupyter_kernel(code)
+sh.jupyter_kernel = None
 
 # Monkey patch the R interpreter interface to support graphics, when
 # used as a decorator.

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -1987,6 +1987,12 @@ def sh(code):
         %sh
         display < sage_logo.png
 
+    .. WARNING::
+
+        The jupyter bash kernel does not separate stdout and stderr as cell is running.
+        It only returns ok or error depending on exit status of last command in the cell.
+        So all cell output captured goes to either stdout or stderr variable, depending
+        on exit status of the last command in the %sh cell.
     """
     if sh.jupyter_kernel is None:
         sh.jupyter_kernel = jupyter("bash")

--- a/src/smc_sagews/smc_sagews/sage_server_command_line.py
+++ b/src/smc_sagews/smc_sagews/sage_server_command_line.py
@@ -1,6 +1,7 @@
 # A very simple interface exposed from setup.py
 
 import os, socket, sys
+import time
 
 def log(s):
     sys.stderr.write('sage_server: %s\n'%s)
@@ -33,7 +34,9 @@ def main(action='', daemon=True):
         open(logfile, 'w')  # for now we clear it on restart...
         log("setting logfile to %s"%logfile)
 
+        t0 = time.time()
         import sage_server
+        log("seconds to import sage_server: %s"%(time.time() - t0))
         run_server = lambda: sage_server.run_server(port=port, host='127.0.0.1', pidfile=pidfile, logfile=logfile)
         if daemon:
             log("daemonizing")
@@ -49,8 +52,9 @@ def main(action='', daemon=True):
         if os.path.exists(pidfile):
             try:
                 pid = int(open(pidfile).read())
-                log("killing %s"%pid)
-                os.kill(pid, 9)
+                sid = os.getsid(pid)
+                log("killing sid %s"%sid)
+                os.killpg(sid, 9)
                 log("successfully killed")
             except Exception, e:
                 log("failed -- %s"%e)

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -248,25 +248,36 @@ def set_salvus_path(self, id):
     """
     m = self._new('execute_code', locals())
 
-default_log_file = os.path.join(os.environ["HOME"], ".smc/sage_server/sage_server.log")
+# hard code SMC for now so we don't have to run with sage wrapper
+SMC = os.path.join(os.environ["HOME"], ".smc")
+default_log_file = os.path.join(SMC, "sage_server", "sage_server.log")
+default_pid_file = os.path.join(SMC, "sage_server", "sage_server.pid")
 
 def get_sage_server_info(log_file = default_log_file):
-    # log file ~/.smc/sage_server/sage_server.log
-    # sample sage_server startup line in first lines of log:
-    # 3136 (2016-08-18 15:02:49.372): Sage server 127.0.0.1:44483
-    try:
-        with open(log_file, "r") as inf:
-            for lno in range(5):
-                line = inf.readline().strip()
-                m = re.search("Sage server (?P<host>[\w.]+):(?P<port>\d+)$", line)
-                if m:
-                    host = m.group('host')
-                    port = int(m.group('port'))
-                    break
-            else:
-                raise ValueError('Server info not found in log_file',log_file)
-    except IOError:
+    for loop_count in range(3):
+        # log file ~/.smc/sage_server/sage_server.log
+        # sample sage_server startup line in first lines of log:
+        # 3136 (2016-08-18 15:02:49.372): Sage server 127.0.0.1:44483
+        try:
+            with open(log_file, "r") as inf:
+                for lno in range(5):
+                    line = inf.readline().strip()
+                    m = re.search("Sage server (?P<host>[\w.]+):(?P<port>\d+)$", line)
+                    if m:
+                        host = m.group('host')
+                        port = int(m.group('port'))
+                        #return host, int(port)
+                        break
+                else:
+                    raise ValueError('Server info not found in log_file',log_file)
+                break
+        except IOError:
+            print("starting new sage_server")
+            os.system("smc-sage-server start")
+            time.sleep(5.0)
+    else:
         pytest.fail("Unable to open log file %s\nThere is probably no sage server running. You either have to open a sage worksheet or run smc-sage-server start"%log_file)
+    print("got host %s  port %s"%(host, port))
     return host, int(port)
 
 secret_token = None
@@ -297,6 +308,34 @@ def recv_til_done(conn, test_id):
             break
     else:
         pytest.fail("too many responses for message id %s"%test_id)
+###
+# Start of fixtures
+###
+
+@pytest.fixture(autouse = True, scope = "session")
+def sage_server_setup(pid_file = default_pid_file, log_file = default_log_file):
+    r"""
+    make sure sage_server pid file exists and process running at given pid
+    """
+    print("initial fixture")
+    try:
+        pid = int(open(pid_file).read())
+        os.kill(pid, 0)
+    except:
+        assert os.geteuid() != 0, "Do not run as root."
+        os.system("pkill -f sage_server_command_line")
+        os.system("rm -f %s"%pid_file)
+        os.system("smc-sage-server start")
+    for loop_count in range(20):
+        time.sleep(0.5)
+        if not os.path.exists(log_file):
+            continue
+        lmsg = "Starting server listening for connections"
+        if lmsg in open(log_file).read():
+            break
+    else:
+        pytest.fail("Unable to start sage_server and setup log file")
+    return
 
 @pytest.fixture()
 def test_id(request):
@@ -458,8 +497,12 @@ def execblob(request, sagews, test_id):
 
     return execblobfn
 
-@pytest.fixture(scope = "session")
+@pytest.fixture(scope = "module")
 def sagews(request):
+    r"""
+    Module-scoped fixture for tests that don't leave
+    extra threads running.
+    """
     # setup connection to sage_server TCP listener
     host, port = get_sage_server_info()
     print("host %s  port %s"%(host, port))
@@ -488,7 +531,32 @@ def sagews(request):
     # teardown needed - terminate session nicely
     # use yield instead of request.addfinalizer in newer versions of pytest
     def fin():
-        conn.send_json(message.terminate_session())
         print("\nExiting Sage client.")
+        conn.send_json(message.terminate_session())
+        # wait several seconds for client to die
+        for loop_count in range(8):
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                # client is dead
+                break
+            time.sleep(0.5)
+        else:
+            print("sending sigterm to %s"%pid)
+            os.kill(pid, signal.SIGTERM)
     request.addfinalizer(fin)
     return conn
+
+import time
+
+@pytest.fixture(scope = "class")
+def own_sage_server(request):
+    assert os.geteuid() != 0, "Do not run as root, will kill all sage_servers."
+    #os.system("pkill -f sage_server_command_line")
+    print("starting new sage_server")
+    os.system("smc-sage-server start")
+    time.sleep(0.5)
+    def fin():
+        print("killing all sage_server processes")
+        os.system("pkill -f sage_server_command_line")
+    request.addfinalizer(fin)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -44,6 +44,11 @@ def test_issue819(exec2):
     output = "22\n"
     exec2(code, output)
 
+def test_search_doc(exec2):
+    code = "search_doc('laurent')"
+    html = "https://www.google.com/search\?q=site%3Adoc.sagemath.org\+laurent\&oq=site%3Adoc.sagemath.org"
+    exec2(code, html_pattern = html)
+
 class TestSearchSrc:
     def test_search_src_simple(self, execinteract):
         execinteract('search_src("convolution")')

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -4,14 +4,35 @@ import pytest
 import conftest
 
 class TestShMode:
+    # start the jupyter bash kernel
+    # do this as separate step to avoid following tests failing due to
+    # issue890 traitlets deprecation warning
+    def test_start_sh(self, exec2):
+        exec2("%sh")
+
     # examples from sh mode docstring in sage_salvus.py
+    # note jupyter kernel text ouput is displayed as html
     def test_single_line(self, exec2):
-        exec2("%sh pwd\n", pattern="^/")
+        exec2("%sh pwd\n", html_pattern=">/")
+
     def test_multiline(self, exec2):
-        exec2("%sh\nFOO=hello\necho $FOO", "hello\n")
+        exec2("%sh\nFOO=hello\necho $FOO", html_pattern="hello")
+
     def test_direct_call(self, exec2):
-        exec2("sh('date +%Y-%m-%d')", pattern = '^\d{4}-\d{2}-\d{2}$')
+        exec2("sh('date +%Y-%m-%d')", html_pattern = '\d{4}-\d{2}-\d{2}')
+
+    # need exec finalizer after each cell for capture
+    # that is why two tests
     def test_capture_sh_01(self, exec2):
-        exec2("%capture(stdout='output')\n%sh\nuptime")
+        exec2("%capture(stdout='output')\n%sh uptime")
     def test_capture_sh_02(self, exec2):
-        exec2("output", pattern="up.*users.*load average")
+        exec2("output", pattern="up.*user.*load average")
+
+    def test_remember_settings_01(self, exec2):
+        exec2("%sh FOO='testing123'", html_pattern="monospace")
+
+    def test_remember_settings_02(self, exec2):
+        exec2("%sh echo $FOO", html_pattern="testing123")
+
+    def test_sh_display(self, execblob, image_file):
+        execblob("%sh display < " + str(image_file))


### PR DESCRIPTION
%sh mode revised to use jupyter bash kernel
- keep state (shell variables, working directory) between %sh cells
- auto completion
- color output for example from `ls`

__warning related to capture__
- jupyter bash kernel does not separate stdout and stderr as cell is running. it only returns `ok` or `error` depending on exit status of last command in the cell. So all cell output captured goes to stdout or stderr depending on last command

__sage_server_command_line__ modified to kill stuck client processes. I suspect these arise more often during testing than normal use. I added this change while testing %sh mode. For details, see https://cloud.sagemath.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/TEST_SAGEWS/test_processes.md section _Reliably creating stuck child process of sage_server._

Run tests with
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews_modes.py::TestShMode
```

I added a test for search_doc() too:
```
python -m pytest test_sagews.py::test_search_doc
```
 