### PR TITLE
don't show line number if line = 1 in users viewing document

### DIFF
--- a/src/smc-webapp/profile.cjsx
+++ b/src/smc-webapp/profile.cjsx
@@ -94,8 +94,7 @@ Avatar = rclass
         return merge(style, @props.style)
 
     render_line: ->
-        if @props.line
-            <span> (Line {@props.line})</span>
+        <span> (Line {@props.line})</span>
 
     tooltip: ->
         {ProjectTitle} = require('./projects')
@@ -104,7 +103,7 @@ Avatar = rclass
         else if @props.viewing_what == 'project'
             <Tooltip id="#{@props.account?.first_name or 'anonymous'}">{@props.account.first_name} {@props.account.last_name} last seen at {@props.path}</Tooltip>
         else
-            <Tooltip id="#{@props.account?.first_name or 'anonymous'}">{@props.account.first_name} {@props.account.last_name}{@render_line()}</Tooltip>
+            <Tooltip id="#{@props.account?.first_name or 'anonymous'}">{@props.account.first_name} {@props.account.last_name}{@render_line() if @props.line > 1}</Tooltip>
 
     render_image: ->
         if @has_image()

--- a/src/smc-webapp/profile.cjsx
+++ b/src/smc-webapp/profile.cjsx
@@ -103,7 +103,7 @@ Avatar = rclass
         else if @props.viewing_what == 'project'
             <Tooltip id="#{@props.account?.first_name or 'anonymous'}">{@props.account.first_name} {@props.account.last_name} last seen at {@props.path}</Tooltip>
         else
-            <Tooltip id="#{@props.account?.first_name or 'anonymous'}">{@props.account.first_name} {@props.account.last_name}{@render_line() if @props.line > 1}</Tooltip>
+            <Tooltip id="#{@props.account?.first_name or 'anonymous'}">{@props.account.first_name} {@props.account.last_name}{@render_line() if @props.line}</Tooltip>
 
     render_image: ->
         if @has_image()
@@ -271,10 +271,10 @@ UsersViewing = rclass
                 if @props.account_id is user_id
                     continue
                 z = @props.get_users_cursors?(user_id)?[0]?['y']
-                if z?
-                    line = z  + 1
+                if z is undefined
+                    line = undefined
                 else
-                    line = 1
+                    line = z  + 1
                 account = @props.user_map.get(user_id)?.toJS() ? {}
                 [event, seconds] = @_find_most_recent(events)
                 time_since =  salvus_client.server_time()/1000 - seconds


### PR DESCRIPTION
This would address editors like chat where line numbers make no sense