### PR TITLE
Iphone and android chrome input fixes

### DIFF
--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -66,7 +66,7 @@ editing   : immutable.Map
 
 # standard non-SMC libraries
 immutable = require('immutable')
-{IS_MOBILE} = require('./feature')
+{IS_MOBILE, isMobile} = require('./feature')
 underscore = require('underscore')
 
 # SMC libraries
@@ -1024,18 +1024,32 @@ ChatRoom = (name) -> rclass
                 </Row>
                 <Row>
                     <Col xs={10} style={padding:'0px 2px 0px 2px'}>
-                        <Input
-                            autoFocus   = {true}
-                            rows        = 2
-                            type        = 'textarea'
-                            ref         = 'input'
-                            onKeyDown   = {@keydown}
-                            value       = {@props.input}
-                            placeholder = {'Type a message...'}
-                            onClick     = {@mark_as_read}
-                            onChange    = {(value)=>@props.actions.set_input(@refs.input.getValue())}
-                            style       = {@mobile_chat_input_style}
-                            />
+                        {if isMobile.Android()
+                            <Input
+                                autoFocus   = {true}
+                                rows        = 2
+                                type        = 'textarea'
+                                ref         = 'input'
+                                onKeyDown   = {@keydown}
+                                value       = {@props.input}
+                                placeholder = {'Type a message...'}
+                                onClick     = {@mark_as_read}
+                                onChange    = {(value)=>@props.actions.set_input(@refs.input.getValue())}
+                                style       = {@mobile_chat_input_style}
+                                />
+                        else
+                            <Input
+                                autoFocus   = {false}
+                                rows        = 2
+                                type        = 'textarea'
+                                ref         = 'input'
+                                onKeyDown   = {@keydown}
+                                value       = {@props.input}
+                                placeholder = {'Type a message...'}
+                                onClick     = {@mark_as_read}
+                                onChange    = {(value)=>@props.actions.set_input(@refs.input.getValue())}
+                                style       = {@mobile_chat_input_style}
+                                />}
                     </Col>
                     <Col xs={2} style={height:'57px', padding:'0px 2px 0px 2px'}>
                         <Button onClick={@send_chat} disabled={@props.input==''} bsStyle='primary' style={height:'90%', width:'100%', marginTop:'5px'}>

--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -1022,7 +1022,7 @@ ChatRoom = (name) -> rclass
                 <Row>
                     <Col xs={10} style={padding:'0px 2px 0px 2px'}>
                         <Input
-                            autoFocus   = {if isMobile.Android() then true else false}
+                            autoFocus   = {isMobile.Android()}
                             rows        = 2
                             type        = 'textarea'
                             ref         = 'input'

--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -1021,32 +1021,18 @@ ChatRoom = (name) -> rclass
                 </Row>
                 <Row>
                     <Col xs={10} style={padding:'0px 2px 0px 2px'}>
-                        {if isMobile.Android()
-                            <Input
-                                autoFocus   = {true}
-                                rows        = 2
-                                type        = 'textarea'
-                                ref         = 'input'
-                                onKeyDown   = {@keydown}
-                                value       = {@props.input}
-                                placeholder = {'Type a message...'}
-                                onClick     = {@mark_as_read}
-                                onChange    = {(value)=>@props.actions.set_input(@refs.input.getValue())}
-                                style       = {@mobile_chat_input_style}
-                                />
-                        else
-                            <Input
-                                autoFocus   = {false}
-                                rows        = 2
-                                type        = 'textarea'
-                                ref         = 'input'
-                                onKeyDown   = {@keydown}
-                                value       = {@props.input}
-                                placeholder = {'Type a message...'}
-                                onClick     = {@mark_as_read}
-                                onChange    = {(value)=>@props.actions.set_input(@refs.input.getValue())}
-                                style       = {@mobile_chat_input_style}
-                                />}
+                        <Input
+                            autoFocus   = {if isMobile.Android() then true else false}
+                            rows        = 2
+                            type        = 'textarea'
+                            ref         = 'input'
+                            onKeyDown   = {@keydown}
+                            value       = {@props.input}
+                            placeholder = {'Type a message...'}
+                            onClick     = {@mark_as_read}
+                            onChange    = {(value)=>@props.actions.set_input(@refs.input.getValue())}
+                            style       = {@mobile_chat_input_style}
+                            />
                     </Col>
                     <Col xs={2} style={height:'57px', padding:'0px 2px 0px 2px'}>
                         <Button onClick={@send_chat} disabled={@props.input==''} bsStyle='primary' style={height:'90%', width:'100%', marginTop:'5px'}>


### PR DESCRIPTION
Fixes issue #669 
Changed auto focus to false on ios since we don't want to auto focus most forms on mobile. Changing auto focus to false on android messes up the input, so auto focus is set to true and it works.
