### PR TITLE
When copying a directory to another project's home directory, the copy button was grayed out

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1201,7 +1201,7 @@ ProjectFilesActionBox = rclass
     valid_copy_input : ->
         src_path = misc.path_split(@props.checked_files.first()).head
         input = @state.copy_destination_directory
-        if input == src_path
+        if input == src_path and @props.project_id == @state.copy_destination_project_id
             return false
         if @state.copy_destination_project_id is ''
             return false


### PR DESCRIPTION
I needed to copy a directory of files from one project to another project, and I wanted my directory to reside in the home directory of the new project. 

The copy button was grayed out. 

Then @hsy and I chose an arbitrary destination directory, and it successfully copied it there. This means I had to move it from its arbitrary destination into the home directory of the new project.

Yet, surely, it should be possible to copy something into a new project's home directory.