### PR TITLE
sometimes a project's home directory is owned by root (so wrong permissions)

### DIFF
--- a/src/smc_pyutil/smc_pyutil/smc_compute.py
+++ b/src/smc_pyutil/smc_pyutil/smc_compute.py
@@ -235,10 +235,10 @@ class Project(object):
             self.cmd(['/usr/bin/pkill', '-9', '-u', self.uid], ignore_errors=True)
         log("WARNING: failed to kill all procs after %s tries"%max_tries)
 
-    def chown(self, path):
+    def chown(self, path, recursive=True):
         if self._dev:
             return
-        cmd(["chown", "%s:%s"%(self.uid, self.uid), '-R', path])
+        cmd(["chown", "%s:%s"%(self.uid, self.uid), '-R' if recursive else '', path])
 
     def ensure_file_exists(self, src, target):
         target = os.path.abspath(target)
@@ -386,6 +386,7 @@ class Project(object):
         self.remove_snapshots_path()
         self.create_user()
         self.create_smc_path()
+        self.chown(self.project_path, False) # Sometimes /projects/[project_id] doesn't have group/owner equal to that of the project.
 
         os.environ['SMC_BASE_URL'] = base_url
 


### PR DESCRIPTION
Sometimes /projects/[project_id] doesn't have group/owner equal to that of the project.  Add a check or something in src/smc_pyutil/smc_pyutil/smc_compute.py to ensure it does whenever starting the project.

(Don't just chown the whole tree though, since that can take a very long time and is usually wasteful.)