### PR TITLE
make it possible to draw plots in %octave mode on Sage worksheets

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -84,6 +84,7 @@ class JUPYTER(object):
     __doc__ = property(_get_doc)
 
 jupyter = JUPYTER()
+octave = jupyter('octave')
 
 import jupyter_client
 from Queue import Empty


### PR DESCRIPTION
Even the most basic thing is completely utterly broken.  This

```
%octave
x = -10:0.1:10;
plot (x, sin (x));
```

hangs forever, and similarly, in the command line, this hangs forever:

```
sage: octave.eval("x = -10:0.1:10;\nplot (x, sin (x));")
```

Help from Nils/Andrey:

```
On Friday, November 6, 2015 at 2:59:56 PM UTC-8, Andrey Novoseltsev wrote:
My understanding is that (unlike for R) we do not try to do anything for Octave plotting, 
so everything is "default". Plotting commands in Octave use either gnuplot or OpenGL,
 but it seems that in our setup only gnuplot is available. How extractly it is used I don't 
know, but my guess is that Octave creates some input file and then passes it to "gnuplot" 
and you have an option to change the name of the called binary and supply some
 options to it. For whatever reason, default options result in just ASCII plot in 
SageMathCell and SageNB. When I try to add explicit commands for saving in a 
particular format I am just getting the same ASCII plot one more time and some 
warnings. Starting Octave from a local terminal allows me to open plots in a new 
window, while saving files works but still shows warning about missing things. 
It would be nice if someone who knows Octave and gnuplot figured out what do 
we need to do to get some plots and no warnings - I am stopping for now.

I don't know either very much, but I have succeeded on my local octave (on 
Fedora) to produce some plots in files via essentially this code:

https://sagecell.sagemath.org/?z=eJxLy0wvLUrVMNRRKssszkzKSVXSUcpPS1PS5OUqLi1K0yhITcwuBnESy1ITi0HqwCJ6BXnpIDUAiBwTdA==&lang=octave 

figure(1,"visible","off")
surf(peaks)
saveas(1,"peaks.png")

(saving to peak.pdf works too).

I did install "transfig" (a part of xfig), as well as "pstoedit". 

Turning the "visible" off ensures that you don't get the silly ascii art.

Other remarks:

I do need to run octave with "DISPLAY" unset. Otherwise it seems to want to use the 
graphics windows things, and from there any attempt to saving the graphics leads to a
 segfault [which has significantly diminished my trust in octave, or at least its fedora
 packaging]. Even with "visible" off, I wasn't getting saved graphics (but no segfaults either).

It would be great if we could get basic octave graphics support running on sagecell. I 
think plenty of matlab-centric courses could make excellent use of it.
```
