### PR TITLE
sagews %sh autocomplete

### DIFF
--- a/src/dev/docker/README.md
+++ b/src/dev/docker/README.md
@@ -9,7 +9,7 @@ This is a self-contained single-image multi-user SageMathCloud server.
 
 ## Instructions
 
-**Technical Note: This Docker image only supports 64-bit.**
+**Technical Note: This Docker image only supports 64-bit Intel.**
 
 To download the latest docker image (about 7GB):
 

--- a/src/dev/docker/README.md
+++ b/src/dev/docker/README.md
@@ -9,6 +9,8 @@ This is a self-contained single-image multi-user SageMathCloud server.
 
 ## Instructions
 
+**Technical Note: This Docker image only supports 64-bit.**
+
 To download the latest docker image (about 7GB):
 
     docker pull  williamstein/sagemathcloud

--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -107,9 +107,6 @@ def _jkmagic(kernel_name, **kwargs):
     """
     km, kc = jupyter_client.manager.start_new_kernel(kernel_name = kernel_name)
 
-    kn = kernel_name
-    i_am_a_jupyter_client = True
-
     debug = kwargs['debug'] if 'debug' in kwargs else False
 
     def p(*args):
@@ -142,11 +139,10 @@ def _jkmagic(kernel_name, **kwargs):
             h2 = '<div style="max-height:320px;width:80%;overflow:auto;">' + h2 + '</div>'
         salvus.html(h2)
 
-    def run_code(code):
+    def run_code(code, get_kernel_name = False):
 
-        # these are used by the worksheet process
-        if (not i_am_a_jupyter_client) or len(kn) == 0:
-            return
+        if get_kernel_name:
+            return kernel_name
 
         # execute the code
         msg_id = kc.execute(code)

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1515,13 +1515,10 @@ def session(conn):
                             prefix = top[1:]
                     try:
                         # see if prefix is the name of a jupyter kernel function
-                        # to qualify, prefix should be the name of a function
-                        # and that function has free variables "i_am_a_jupyter_client" and "kn"
                         jkfn = namespace[prefix]
-                        jupyter_client_index = jkfn.func_code.co_freevars.index("i_am_a_jupyter_client")
-                        jkix = jkfn.func_code.co_freevars.index("kn") # e.g. 3
-                        jkname = jkfn.func_closure[jkix].cell_contents # e.g. "python2"
-                        # consider also checking for jkname in list of jupyter kernels
+                        if hasattr(jkfn, 'jupyter_kernel'):
+                            jkfn = jkfn.jupyter_kernel
+                        jkname = jkfn(None, get_kernel_name = True)
                         log("jupyter introspect %s: %s"%(prefix, jkname)) # e.g. "p2", "python2"
                         jupyter_introspect(conn=conn,
                                            id=mesg['id'],
@@ -1529,7 +1526,10 @@ def session(conn):
                                            preparse=mesg.get('preparse', True),
                                            jkfn=jkfn)
                     except:
-                        # non-jupyter introspection
+                        #import traceback
+                        #exc_type, exc_value, exc_traceback = sys.exc_info()
+                        #lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                        #log(lines)
                         introspect(conn=conn, id=mesg['id'], line=mesg['line'], preparse=mesg.get('preparse', True))
                 except:
                     pass

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1517,6 +1517,7 @@ def session(conn):
                         # see if prefix is the name of a jupyter kernel function
                         jkfn = namespace[prefix]
                         if hasattr(jkfn, 'jupyter_kernel'):
+                            # pre-defined jupyter modes like %sh have mode function in attribute
                             jkfn = jkfn.jupyter_kernel
                         jkname = jkfn(None, get_kernel_name = True)
                         log("jupyter introspect %s: %s"%(prefix, jkname)) # e.g. "p2", "python2"

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -155,10 +155,6 @@ class Message(object):
     def execute_javascript(self, code, obj=None, coffeescript=False):
         return self._new('execute_javascript', locals())
 
-    # NOTE: save_blob() is NOT in sage_server.py
-    def save_blob(self, sha1):
-        return self._new('save_blob', {'sha1':sha1})
-
     def output(self, id,
                stdout       = None,
                stderr       = None,
@@ -235,6 +231,13 @@ class Message(object):
         m = self._new('introspect_source_code', locals())
         m['id'] = id
         return m
+
+    # NOTE: these functions are NOT in sage_server.py
+    def save_blob(self, sha1):
+        return self._new('save_blob', {'sha1':sha1})
+
+    def introspect(self, id, line, top):
+        return self._new('introspect', {'id':id, 'line':line, 'top':top})
 
 message = Message()
 

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -497,7 +497,7 @@ def execblob(request, sagews, test_id):
 
     return execblobfn
 
-@pytest.fixture(scope = "module")
+@pytest.fixture(scope = "class")
 def sagews(request):
     r"""
     Module-scoped fixture for tests that don't leave

--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -1,0 +1,6 @@
+# test_sagews_x.py
+# tests of sage worksheet that return more than stdout, e.g. svg files
+
+class TestGraphics:
+    def test_plot(self, execblob):
+        execblob("plot(cos(x),x,0,pi)")

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -7,47 +7,48 @@ import re
 
 from textwrap import dedent
 
-def test_connection_type(sagews):
-    print("type %s"%type(sagews))
-    assert isinstance(sagews, conftest.ConnectionJSON)
-    return
+class TestBasic:
+    def test_connection_type(self, sagews):
+        print("type %s"%type(sagews))
+        assert isinstance(sagews, conftest.ConnectionJSON)
+        return
 
-def test_set_file_env(exec2):
-    code = "os.chdir(salvus.data[\'path\']);__file__=salvus.data[\'file\']"
-    exec2(code)
+    def test_set_file_env(self, exec2):
+        code = "os.chdir(salvus.data[\'path\']);__file__=salvus.data[\'file\']"
+        exec2(code)
 
-def test_assignment(exec2):
-    code = "x = 42\nx\n"
-    output = "42\n"
-    exec2(code, output)
+    def test_assignment(self, exec2):
+        code = "x = 42\nx\n"
+        output = "42\n"
+        exec2(code, output)
 
-def test_issue70(exec2):
-    code = dedent(r"""
-    for i in range(1):
-        pass
-    'x'
-    """)
-    output = dedent(r"""
-    'x'
-    """).lstrip()
-    exec2(code, output)
+    def test_issue70(self, exec2):
+        code = dedent(r"""
+        for i in range(1):
+            pass
+        'x'
+        """)
+        output = dedent(r"""
+        'x'
+        """).lstrip()
+        exec2(code, output)
 
-def test_issue819(exec2):
-    code = dedent(r"""
-    def never_called(a):
-        print 'should not execute 1', a
-        # comment
-    # comment at indent 0
-        print 'should not execute 2', a
-    22
-    """)
-    output = "22\n"
-    exec2(code, output)
+    def test_issue819(self, exec2):
+        code = dedent(r"""
+        def never_called(a):
+            print 'should not execute 1', a
+            # comment
+        # comment at indent 0
+            print 'should not execute 2', a
+        22
+        """)
+        output = "22\n"
+        exec2(code, output)
 
-def test_search_doc(exec2):
-    code = "search_doc('laurent')"
-    html = "https://www.google.com/search\?q=site%3Adoc.sagemath.org\+laurent\&oq=site%3Adoc.sagemath.org"
-    exec2(code, html_pattern = html)
+    def test_search_doc(self, exec2):
+        code = "search_doc('laurent')"
+        html = "https://www.google.com/search\?q=site%3Adoc.sagemath.org\+laurent\&oq=site%3Adoc.sagemath.org"
+        exec2(code, html_pattern = html)
 
 class TestSearchSrc:
     def test_search_src_simple(self, execinteract):

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -34,8 +34,6 @@ class TestShMode:
 
     def test_sh_display(self, execblob, image_file):
         execblob("%sh display < " + str(image_file))
-# {u\'preparse\': True, u\'line\': u\'echo $VAR\', u\'top\': u"# autocomplete - don\'t run this cell, put cursor after VAR and hit [TAB]", u\'event\': u\'introspect\', u\'id\': u\'b4542e8b-9f5d-4736-87f6-af37f16d443a\'}
-# {"id": "b4542e8b-9f5d-4736-87f6-af37f16d443a", "event": "introspect_completions", "completions": ["1","2"], "target": "$VAR"}
     def test_sh_autocomplete_01(self, exec2):
         exec2("%sh TESTVAR29=xyz")
     def test_sh_autocomplete_02(self, test_id, sagews):

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -21,8 +21,6 @@ class TestShMode:
     def test_direct_call(self, exec2):
         exec2("sh('date +%Y-%m-%d')", html_pattern = '\d{4}-\d{2}-\d{2}')
 
-    # need exec finalizer after each cell for capture
-    # that is why two tests
     def test_capture_sh_01(self, exec2):
         exec2("%capture(stdout='output')\n%sh uptime")
     def test_capture_sh_02(self, exec2):
@@ -36,3 +34,17 @@ class TestShMode:
 
     def test_sh_display(self, execblob, image_file):
         execblob("%sh display < " + str(image_file))
+# {u\'preparse\': True, u\'line\': u\'echo $VAR\', u\'top\': u"# autocomplete - don\'t run this cell, put cursor after VAR and hit [TAB]", u\'event\': u\'introspect\', u\'id\': u\'b4542e8b-9f5d-4736-87f6-af37f16d443a\'}
+# {"id": "b4542e8b-9f5d-4736-87f6-af37f16d443a", "event": "introspect_completions", "completions": ["1","2"], "target": "$VAR"}
+    def test_sh_autocomplete_01(self, exec2):
+        exec2("%sh TESTVAR29=xyz")
+    def test_sh_autocomplete_02(self, test_id, sagews):
+        m = conftest.message.introspect(test_id, line='echo $TESTV', top='%sh')
+        m['preparse'] = True
+        sagews.send_json(m)
+        typ, mesg = sagews.recv()
+        assert typ == 'json'
+        assert mesg['id'] == test_id
+        assert mesg['event'] == "introspect_completions"
+        assert mesg['completions'] == ["AR29"]
+        assert mesg['target'] == "$TESTV"

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_timing.py
@@ -47,95 +47,96 @@ class TestSageTiming:
         assert elapsed < 10.0
 
 @pytest.mark.no_session
-def test_2plus2_timing(test_id):
-    if('no_session' not in pytest.config.option.markexpr):
-        pytest.skip("this test requires pytest -m no_session")
+class TestSagewsNoSession:
+    def test_2plus2_timing(self, test_id):
+        if('no_session' not in pytest.config.option.markexpr):
+            pytest.skip("this test requires pytest -m no_session")
 
-    import sys
+        import sys
 
-    # if sage_server is running, stop it
-    os.system("smc-sage-server stop")
+        # if sage_server is running, stop it
+        os.system("smc-sage-server stop")
 
-    # start the clock
-    start = time.time()
+        # start the clock
+        start = time.time()
 
-    # start a new sage_server process
-    os.system("smc-sage-server start")
-    print("sage_server start time %s sec"%(time.time() - start))
-    # add pause here because sometimes the log file isn't ready immediately
-    time.sleep(0.5)
-
-    # setup connection to sage_server TCP listener
-    host, port = conftest.get_sage_server_info()
-    print("host %s  port %s"%(host, port))
-
-    # multiple tries at connecting because there's a delay between
-    # writing the port number and listening on the socket for connections
-    for attempt in range(10):
-        attempt += 1
-        print("attempt %s"%attempt)
-        try:
-
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect((host, port))
-            break
-        except:
-            print(sys.exc_info()[0])
-            pass
+        # start a new sage_server process
+        os.system("smc-sage-server start")
+        print("sage_server start time %s sec"%(time.time() - start))
+        # add pause here because sometimes the log file isn't ready immediately
         time.sleep(0.5)
-    else:
-        pytest.fail("Could not connect to sage_server at port %s"%port)
-    print("connected to socket")
 
-    # unlock
-    conftest.client_unlock_connection(sock)
-    print("socket unlocked")
-    conn = conftest.ConnectionJSON(sock)
-    c_ack = conn._recv(1)
-    assert c_ack == 'y',"expect ack for token, got %s"%c_ack
+        # setup connection to sage_server TCP listener
+        host, port = conftest.get_sage_server_info()
+        print("host %s  port %s"%(host, port))
 
-    # start session
-    msg = conftest.message.start_session()
-    msg['type'] = 'sage'
-    conn.send_json(msg)
-    print("start_session sent")
-    typ, mesg = conn.recv()
-    assert typ == 'json'
-    pid = mesg['pid']
-    print("sage_server PID = %s" % pid)
+        # multiple tries at connecting because there's a delay between
+        # writing the port number and listening on the socket for connections
+        for attempt in range(10):
+            attempt += 1
+            print("attempt %s"%attempt)
+            try:
 
-    code = "2+2\n"
-    output = "4\n"
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.connect((host, port))
+                break
+            except:
+                print(sys.exc_info()[0])
+                pass
+            time.sleep(0.5)
+        else:
+            pytest.fail("Could not connect to sage_server at port %s"%port)
+        print("connected to socket")
 
-    m = conftest.message.execute_code(code = code, id = test_id)
-    m['preparse'] = True
+        # unlock
+        conftest.client_unlock_connection(sock)
+        print("socket unlocked")
+        conn = conftest.ConnectionJSON(sock)
+        c_ack = conn._recv(1)
+        assert c_ack == 'y',"expect ack for token, got %s"%c_ack
 
-    # send block of code to be executed
-    conn.send_json(m)
+        # start session
+        msg = conftest.message.start_session()
+        msg['type'] = 'sage'
+        conn.send_json(msg)
+        print("start_session sent")
+        typ, mesg = conn.recv()
+        assert typ == 'json'
+        pid = mesg['pid']
+        print("sage_server PID = %s" % pid)
 
-    # check stdout
-    typ, mesg = conn.recv()
-    assert typ == 'json'
-    assert mesg['id'] == test_id
-    assert mesg['stdout'] == output
-    elapsed = time.time() - start
+        code = "2+2\n"
+        output = "4\n"
 
-    # teardown connection
-    conn.send_json(conftest.message.terminate_session())
-    print("\nExiting Sage client.")
-    # wait 3 sec for process to die, then kill it
-    for loop_count in range(6):
-        try:
-            os.kill(pid, 0)
-        except OSError:
-            pass
-        time.sleep(0.5)
-    else:
-        print("sending sigterm to %s"%pid)
-        os.kill(pid, signal.SIGTERM)
+        m = conftest.message.execute_code(code = code, id = test_id)
+        m['preparse'] = True
 
-    # check timing
-    print("elapsed 2+2 %s"%elapsed)
-    assert elapsed < 8.0
+        # send block of code to be executed
+        conn.send_json(m)
 
-    return
+        # check stdout
+        typ, mesg = conn.recv()
+        assert typ == 'json'
+        assert mesg['id'] == test_id
+        assert mesg['stdout'] == output
+        elapsed = time.time() - start
+
+        # teardown connection
+        conn.send_json(conftest.message.terminate_session())
+        print("\nExiting Sage client.")
+        # wait 3 sec for process to die, then kill it
+        for loop_count in range(6):
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                pass
+            time.sleep(0.5)
+        else:
+            print("sending sigterm to %s"%pid)
+            os.kill(pid, signal.SIGTERM)
+
+        # check timing
+        print("elapsed 2+2 %s"%elapsed)
+        assert elapsed < 8.0
+
+        return

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_x.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_x.py
@@ -1,7 +1,0 @@
-# test_sagews_x.py
-# tests of sage worksheet that return more than stdout, e.g. svg files
-
-def test_plot(execblob):
-    execblob("plot(cos(x),x,0,pi)")
-
-###


### PR DESCRIPTION
Ref. #920 

This PR fixes autocomplete for direct and default %sh mode and adds pytest for those.

Test with
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews_modes.py::TestShMode
```

Not fixed in this PR: %capture with %default_mode sh.