### PR TITLE
fix capture for default modes for sh and r, add pytest cases

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -1591,6 +1591,9 @@ class Capture:
     def __call__(self, code=None, stdout=None, stderr=None, append=False, echo=False):
         if code is None:
             return Capture(stdout=stdout, stderr=stderr, append=append, echo=echo)
+        if salvus._prefix:
+            if not code.startswith("%"):
+                code = salvus._prefix + '\n' + code
         salvus.execute(code)
 
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -34,6 +34,7 @@ class TestShMode:
 
     def test_sh_display(self, execblob, image_file):
         execblob("%sh display < " + str(image_file))
+
     def test_sh_autocomplete_01(self, exec2):
         exec2("%sh TESTVAR29=xyz")
     def test_sh_autocomplete_02(self, test_id, sagews):
@@ -46,3 +47,64 @@ class TestShMode:
         assert mesg['event'] == "introspect_completions"
         assert mesg['completions'] == ["AR29"]
         assert mesg['target'] == "$TESTV"
+
+class TestShDefaultMode:
+    def test_start_sh(self, exec2):
+        exec2("%default_mode sh")
+    def test_start_sh2(self, exec2):
+        exec2("pwd")
+
+    def test_single_line(self, exec2):
+        exec2("pwd\n", html_pattern=">/")
+
+    def test_multiline(self, exec2):
+        exec2("FOO=hello\necho $FOO", html_pattern="hello")
+
+    def test_date(self, exec2):
+        exec2("date +%Y-%m-%d", html_pattern = '\d{4}-\d{2}-\d{2}')
+
+    def test_capture_sh_01(self, exec2):
+        exec2("%capture(stdout='output')\nuptime")
+    def test_capture_sh_02(self, exec2):
+        exec2("%sage\noutput", pattern="up.*user.*load average")
+
+    def test_remember_settings_01(self, exec2):
+        exec2("FOO='testing123'", html_pattern="monospace")
+    def test_remember_settings_02(self, exec2):
+        exec2("echo $FOO", html_pattern="testing123")
+
+    def test_sh_display(self, execblob, image_file):
+        execblob("display < " + str(image_file))
+
+    def test_sh_autocomplete_01(self, exec2):
+        exec2("TESTVAR29=xyz")
+    def test_sh_autocomplete_02(self, test_id, sagews):
+        m = conftest.message.introspect(test_id, line='echo $TESTV', top='')
+        m['preparse'] = True
+        sagews.send_json(m)
+        typ, mesg = sagews.recv()
+        assert typ == 'json'
+        assert mesg['id'] == test_id
+        assert mesg['event'] == "introspect_completions"
+        assert mesg['completions'] == ["AR29"]
+        assert mesg['target'] == "$TESTV"
+
+class TestRMode:
+    def test_assignment(self, exec2):
+        exec2("%r\nxx <- c(4,7,13)\nmean(xx)", "[1] 8")
+
+    def test_capture_r_01(self, exec2):
+        exec2("%capture(stdout='output')\n%r\nsum(xx)")
+    def test_capture_r_02(self, exec2):
+        exec2("print(output)", "[1] 24\n")
+
+class TestRDefaultMode:
+    def test_set_r_mode(self, exec2):
+        exec2("%default_mode r")
+    def test_assignment(self, exec2):
+        exec2("xx <- c(4,7,13)\nmean(xx)", "[1] 8")
+
+    def test_capture_r_01(self, exec2):
+        exec2("%capture(stdout='output')\nsum(xx)")
+    def test_capture_r_02(self, exec2):
+        exec2("%sage\nprint(output)", "[1] 24\n")


### PR DESCRIPTION
Second part of #920.
- fix %capture with %default_mode sh
- fix %capture with %default_mode r
- add pytest cases for above and simple computation in r

To run pytest cases for this issue:
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews_modes.py
```