### PR TITLE
filter deprecation warnings when starting jupyter kernel

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -105,7 +105,10 @@ def _jkmagic(kernel_name, **kwargs):
     -  ``debug`` - optional, set true to view jupyter messages
 
     """
-    km, kc = jupyter_client.manager.start_new_kernel(kernel_name = kernel_name)
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        km, kc = jupyter_client.manager.start_new_kernel(kernel_name = kernel_name)
 
     debug = kwargs['debug'] if 'debug' in kwargs else False
 


### PR DESCRIPTION
Fixes #890, sagews pytest updated.

to test:
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews_modes.py::TestShMode
```

