### PR TITLE
Issue355octave

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -156,7 +156,7 @@ def _jkmagic(kernel_name, **kwargs):
         stdinj = kc.stdin_channel
 
         # buffering for %capture because we don't know whether output is stdout or stderr
-        # until shell execute_reply messasge is received with status 'ok' or 'error'
+        # until shell execute_reply message is received with status 'ok' or 'error'
         capture_out = ""
 
         # handle iopub messages
@@ -228,10 +228,11 @@ def _jkmagic(kernel_name, **kwargs):
                     continue
                 p('execute_result data keys: ',content['data'].keys())
                 out_prefix = ""
-                if 'execution_count' in content:
-                    out_data = "Out [%d]: "%content['execution_count']
-                    # don't want line break after this
-                    sys.stdout.write(out_data)
+                # don't display output numbers
+                # if 'execution_count' in content:
+                #     out_data = "Out [%d]: "%content['execution_count']
+                #     # don't want line break after this
+                #     sys.stdout.write(out_data)
                 if 'text/latex' in content['data']:
                     ldata = content['data']['text/latex']
                     if re.match('\W*begin{tabular}',ldata):

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2010,6 +2010,14 @@ def sh(code):
     return sh.jupyter_kernel(code)
 sh.jupyter_kernel = None
 
+# use jupyter kernel for GNU octave instead of sage interpreter interface
+def octave(code):
+    if octave.jupyter_kernel is None:
+        octave.jupyter_kernel = jupyter("octave")
+    return octave.jupyter_kernel(code)
+octave.jupyter_kernel = None
+
+
 # Monkey patch the R interpreter interface to support graphics, when
 # used as a decorator.
 

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1772,7 +1772,7 @@ def serve(port, host, extra_imports=False):
                      'reset', 'restore', 'md', 'load', 'attach', 'runfile', 'typeset_mode', 'default_mode',
                      'sage_chat', 'fortran', 'modes', 'go', 'julia', 'pandoc', 'wiki', 'plot3d_using_matplotlib',
                      'mediawiki', 'help', 'raw_input', 'clear', 'delete_last_output', 'sage_eval',
-                     'search_doc','search_src', 'license']:
+                     'search_doc','search_src', 'octave', 'license']:
             namespace[name] = getattr(sage_salvus, name)
 
         namespace['sage_server'] = sys.modules[__name__]    # http://stackoverflow.com/questions/1676835/python-how-do-i-get-a-reference-to-a-module-inside-the-module-itself

--- a/src/smc_sagews/smc_sagews/tests/README.md
+++ b/src/smc_sagews/smc_sagews/tests/README.md
@@ -11,7 +11,6 @@
 ### Prerequisites
 
 - pytest must be installed
-- sage_server must be running
 - file ~/.smc/sage_server/sage_server.log must exist and have the
    current port number around line 3, like this:
    ```
@@ -23,10 +22,4 @@
 ```
 cd smc/src/smc_sagews/smc_sagews
 python -m pytest tests [-s]
-```
-
-Some tests require restarting the sage_server process. These would interfere with fixtures that do sage session setup once at the beginning of a test run and teardown at the end of the run. These tests are skipped by default. To run tests that would disrupt the default test session fixture, invoke tests with ONE of the following:
-```
-pytest -m no_session tests [-s]
-python -m pytest -m no_session tests [-s]
 ```

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -374,15 +374,16 @@ def exec2(request, sagews, test_id):
 
     OUTPUT:
 
-    Fixture function exec2, which takes three arguments. The second and
-    third arguments may be omitted. If both are omitted, the cell is not
+    Fixture function exec2. If output & patterns are omitted, the cell is not
     expected to produce a stdout result.
 
     - `` code `` -- string of code block to run
 
     - `` output `` -- string of expected output, to be matched exactly
 
-    - `` pattern `` -- regex to match with expected output
+    - `` pattern `` -- regex to match with expected stdout output
+
+    - `` html_pattern `` -- regex to match with expected html output
 
     EXAMPLES:
 

--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -1,6 +1,12 @@
-# test_sagews_x.py
+# test_graphics.py
 # tests of sage worksheet that return more than stdout, e.g. svg files
 
 class TestGraphics:
     def test_plot(self, execblob):
         execblob("plot(cos(x),x,0,pi)")
+
+class TestOctavePlot:
+    def test_plot(self,execblob):
+        # assume octave kernel not running at start of test
+        execblob("%octave\nx = -10:0.1:10;plot (x, sin (x));")
+

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -133,3 +133,12 @@ class TestOctaveMode:
         code = "%octave\nformat short\nairy(3,2)\nbeta(2,2)\nbetainc(0.2,2,2)\nbesselh(0,2)"
         outp = "ans =  4.1007\s+ans =  0.16667\s+ans =  0.10400\s+ans =  0.22389 \+ 0.51038i"
         exec2(code, pattern = outp)
+
+class TestOctaveDefaultMode:
+    def test_octave_capture1(self, exec2):
+        exec2("%default_mode octave")
+    def test_octave_capture2(self, exec2):
+        exec2("%capture(stdout='output')\nx = [1,2]", html_pattern = "DOCTYPE HTML PUBLIC")
+    def test_octave_capture3(self, exec2):
+        exec2("%sage\nprint(output)", pattern = "   1   2")
+

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -129,22 +129,7 @@ class TestOctaveMode:
     def test_start_octave(self, exec2):
         exec2("%octave", html_pattern = "DOCTYPE HTML PUBLIC")
 
-    def test_euler(self, test_id, sagews):
-        code = "%octave\nexp (i*pi)"
-        patn = "ans = -1.0000e+00 + 1.2246e-16i"
-        m = conftest.message.execute_code(code = code, id = test_id)
-        m['preparse'] = True
-        sagews.send_json(m)
-        for loop_count in range(5):
-            typ, mesg = sagews.recv()
-            assert typ == 'json'
-            assert mesg['id'] == test_id
-            assert 'stdout' in mesg
-            assert 'stderr' not in mesg
-            if patn in mesg['stdout']:
-                break
-        else:
-            pytest.fail("octave euler test failed %s"%test_id)
-        conftest.recv_til_done(sagews, test_id)
-
-
+    def test_octave_calc(self, exec2):
+        code = "%octave\nformat short\nairy(3,2)\nbeta(2,2)\nbetainc(0.2,2,2)\nbesselh(0,2)"
+        outp = "ans =  4.1007\s+ans =  0.16667\s+ans =  0.10400\s+ans =  0.22389 \+ 0.51038i"
+        exec2(code, pattern = outp)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -124,3 +124,27 @@ class TestRDefaultMode:
         exec2("%capture(stdout='output')\nsum(xx)")
     def test_capture_r_02(self, exec2):
         exec2("%sage\nprint(output)", "[1] 24\n")
+
+class TestOctaveMode:
+    def test_start_octave(self, exec2):
+        exec2("%octave", html_pattern = "DOCTYPE HTML PUBLIC")
+
+    def test_euler(self, test_id, sagews):
+        code = "%octave\nexp (i*pi)"
+        patn = "ans = -1.0000e+00 + 1.2246e-16i"
+        m = conftest.message.execute_code(code = code, id = test_id)
+        m['preparse'] = True
+        sagews.send_json(m)
+        for loop_count in range(5):
+            typ, mesg = sagews.recv()
+            assert typ == 'json'
+            assert mesg['id'] == test_id
+            assert 'stdout' in mesg
+            assert 'stderr' not in mesg
+            if patn in mesg['stdout']:
+                break
+        else:
+            pytest.fail("octave euler test failed %s"%test_id)
+        conftest.recv_til_done(sagews, test_id)
+
+

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_timing.py
@@ -46,12 +46,8 @@ class TestSageTiming:
         print("elapsed %s"%elapsed)
         assert elapsed < 10.0
 
-@pytest.mark.no_session
 class TestSagewsNoSession:
     def test_2plus2_timing(self, test_id):
-        if('no_session' not in pytest.config.option.markexpr):
-            pytest.skip("this test requires pytest -m no_session")
-
         import sys
 
         # if sage_server is running, stop it


### PR DESCRIPTION
Issue/bug #355.
- %octave mode uses jupyter kernel (this will hide sage octave())
- add pytest for calculation, plot, capture in default mode octave
- omit output count numbers "[1] xxx" etc. from jupyter kernel outputs
- more pytest refactoring

```
python -m pytest test_sagews_modes.py::TestOctaveMode
python -m pytest test_sagews_modes.py::TestOctaveDefaultMode
python -m pytest test_graphics.py::TestOctavePlot
```