### PR TITLE
webapp: rendering mathjax by first running marked and then analyzing mathjax code. this catches corner cases like `\$999$` in sagews' %md and `foo $999` in chat

### DIFF
--- a/src/smc-webapp/editor_chat.cjsx
+++ b/src/smc-webapp/editor_chat.cjsx
@@ -443,7 +443,9 @@ Message = rclass
         value = misc.smiley
             s: value
             wrap: ['<span class="smc-editor-chat-smiley">', '</span>']
+        #value_old = value
         value = misc_page.sanitize_html(value)
+        #console.log "sanitize: '#{value_old}' -> '#{value}'"
 
         font_size = "#{@props.font_size}px"
 

--- a/src/smc-webapp/last.coffee
+++ b/src/smc-webapp/last.coffee
@@ -59,10 +59,13 @@ window.MathJax =
     skipStartupTypeset: true
     extensions: ["tex2jax.js","asciimath2jax.js"]  # "static/mathjax_extensions/xypic.js"
     jax: ["input/TeX","input/AsciiMath", "output/SVG"]
+    # http://docs.mathjax.org/en/latest/options/tex2jax.html
     tex2jax:
         inlineMath: [ ['$','$'], ["\\(","\\)"] ]
         displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
         processEscapes: true
+        ignoreClass: "tex2jax_ignore"
+        skipTags: ["script","noscript","style","textarea","pre","code"]
 
     TeX:
         extensions: ["autoload-all.js"]

--- a/src/smc-webapp/markdown.coffee
+++ b/src/smc-webapp/markdown.coffee
@@ -13,6 +13,9 @@ marked.setOptions
     smartypants : true
 
 exports.markdown_to_html = markdown_to_html = (s) ->
+    # render s to html (from markdown)
+    s = marked(s)
+
     # replace mathjax, which is delimited by $, $$, \( \), and \[ \]
     v = misc.parse_mathjax(s)
     if v.length > 0
@@ -29,9 +32,6 @@ exports.markdown_to_html = markdown_to_html = (s) ->
         s = s0 + s.slice(x0[1])
     else
         has_mathjax = false
-
-    # render s to html (from markdown)
-    s = marked(s)
 
     # if there was any mathjax, put it back in the s
     if has_mathjax


### PR DESCRIPTION
This is motivated by #112 but actually solves:

* ```foo `\$999$` bar``` in `%md` in sagews
* `foo $999` in chat

here is some markdown for testing this:

    $a^b$

    `Payment of $99`

    abc `text $ 123` abc

    abc `$a^b$` test

    <pre>
    $a^b$
    </pre>

    ```
    asdf $a^b$ asdf
    asdf
    ```

    <pre>
    $ cd ~
    $ mkdir apps
    </pre>

    ```
    $ nosetests pandas ...
    ..........
    OK (SKIP=2)
    $ test
    ```

    $xxx

    x `$abc` y

    payment of \$ab99

    payment of `\$ab $`

    payment of `\$999$`

    `foo $999`

I've also explicitly added the tags that mathjax should ignore -- there were none specified and these are the defaults. 