### PR TITLE
fix newlines with jupyter bridge #862

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -133,14 +133,18 @@ def _jkmagic(kernel_name, **kwargs):
         -  ``scroll`` - set true to put output into scrolling div
         """
         # `full = False` or else cell output is huge
-        h = conv.convert(s, full = False)
-        if block:
-            h2 = '<pre style="font-family:monospace;">'+h+'</pre>'
+        if "\x1b" in s:
+            h = conv.convert(s, full = False)
+            if block:
+                h2 = '<pre style="font-family:monospace;">'+h+'</pre>'
+            else:
+                h2 = '<pre style="display:inline-block;margin-right:-1ch;font-family:monospace;">'+h+'</pre>'
+            if scroll:
+                h2 = '<div style="max-height:320px;width:80%;overflow:auto;">' + h2 + '</div>'
+            salvus.html(h2)
         else:
-            h2 = '<pre style="display:inline-block;margin-right:-1ch;font-family:monospace;">'+h+'</pre>'
-        if scroll:
-            h2 = '<div style="max-height:320px;width:80%;overflow:auto;">' + h2 + '</div>'
-        salvus.html(h2)
+            sys.stdout.write(s)
+            sys.stdout.flush()
 
     def run_code(code, get_kernel_name = False):
 

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -416,6 +416,7 @@ def exec2(request, sagews, test_id):
         sagews.send_json(m)
 
         # is there an HTML DOCTYPE
+        # common for first response when starting jupyter kernel
         if expect_doctype:
             typ, mesg = sagews.recv()
             assert typ == 'json'
@@ -520,6 +521,7 @@ def sagews(request):
     print("host %s  port %s"%(host, port))
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect((host, port))
+    # jupyter kernels can take over 10 seconds to start
     sock.settimeout(15)
     print("connected to socket")
 

--- a/src/smc_sagews/smc_sagews/tests/test_00_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_00_timing.py
@@ -11,42 +11,7 @@ import os
 import time
 import signal
 
-class TestSageTiming:
-    r"""
-    These tests are to validate the test framework. They do not
-    use sage_server at all.
-    """
-    def test_basic_timing(self):
-        start = time.time()
-        os.system('sleep 1')
-        tick = time.time()
-        elapsed = tick - start
-        assert 1.0 == pytest.approx(elapsed, abs = 0.1)
-
-    def test_load_sage(self):
-        start = time.time()
-        # maybe put first load into fixture
-        os.system("echo '2+2' | /usr/local/bin/sage -python")
-        tick = time.time()
-        elapsed = tick - start
-        print("elapsed 1: %s"%elapsed)
-        # second load after things are cached
-        start = time.time()
-        os.system("echo '2+2' | /usr/local/bin/sage -python")
-        tick = time.time()
-        elapsed = tick - start
-        print("elapsed 2: %s"%elapsed)
-        assert elapsed < 2.0
-
-    def test_import_sage_server(self):
-        start = time.time()
-        os.system("echo 'import sage_server' | /usr/local/bin/sage -python")
-        tick = time.time()
-        elapsed = tick - start
-        print("elapsed %s"%elapsed)
-        assert elapsed < 10.0
-
-class TestSagewsNoSession:
+class TestStartSageServer:
     def test_2plus2_timing(self, test_id):
         import sys
 
@@ -136,3 +101,38 @@ class TestSagewsNoSession:
         assert elapsed < 8.0
 
         return
+
+class TestSageTiming:
+    r"""
+    These tests are to validate the test framework. They do not
+    run sage_server.
+    """
+    def test_basic_timing(self):
+        start = time.time()
+        os.system('sleep 1')
+        tick = time.time()
+        elapsed = tick - start
+        assert 1.0 == pytest.approx(elapsed, abs = 0.1)
+
+    def test_load_sage(self):
+        start = time.time()
+        # maybe put first load into fixture
+        os.system("echo '2+2' | /usr/local/bin/sage -python")
+        tick = time.time()
+        elapsed = tick - start
+        print("elapsed 1: %s"%elapsed)
+        # second load after things are cached
+        start = time.time()
+        os.system("echo '2+2' | /usr/local/bin/sage -python")
+        tick = time.time()
+        elapsed = tick - start
+        print("elapsed 2: %s"%elapsed)
+        assert elapsed < 2.0
+
+    def test_import_sage_server(self):
+        start = time.time()
+        os.system("echo 'import sage_server' | /usr/local/bin/sage -python")
+        tick = time.time()
+        elapsed = tick - start
+        print("elapsed %s"%elapsed)
+        assert elapsed < 10.0

--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -2,6 +2,7 @@
 # tests of sage worksheet that return more than stdout, e.g. svg files
 
 import conftest
+import time
 
 # TODO(hal) refactor this later
 SHA_LEN = 36
@@ -14,8 +15,8 @@ class TestOctavePlot:
     def test_plot(self,execblob):
         # assume octave kernel not running at start of test
         execblob("%octave\nx = -10:0.1:10;plot (x, sin (x));")
-        
-class TestShowPlot:
+
+class TestShowGraphs:
     def test_issue594(self, test_id, sagews):
         code = """G = Graph(sparse=True)
 G.allow_multiple_edges(True)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -6,34 +6,21 @@ import re
 from textwrap import dedent
 
 class TestShMode:
-    def test_start_sh(self, test_id, sagews):
+    def test_start_sh(self, exec2):
         code = "%sh\ndate +%Y-%m-%d"
-        html_pattern = '\d{4}-\d{2}-\d{2}'
-        m = conftest.message.execute_code(code = code, id = test_id)
-        m['preparse'] = True
-        sagews.send_json(m)
-        # skip initial html responses but fail on deprecation warning
-        for loop_count in range(5):
-            typ, mesg = sagews.recv()
-            assert typ == 'json'
-            assert mesg['id'] == test_id
-            assert 'html' in mesg
-            if re.search(html_pattern, mesg['html']) is not None:
-                break
-        else:
-            pytest.fail("sh setup failed %s"%test_id)
-        conftest.recv_til_done(sagews, test_id)
+        patn = '\d{4}-\d{2}-\d{2}'
+        exec2(code, pattern=patn, expect_doctype=True)
 
     # examples from sh mode docstring in sage_salvus.py
     # note jupyter kernel text ouput is displayed as html
     def test_single_line(self, exec2):
-        exec2("%sh pwd\n", html_pattern=">/")
+        exec2("%sh pwd\n", pattern="^/projects")
 
     def test_multiline(self, exec2):
-        exec2("%sh\nFOO=hello\necho $FOO", html_pattern="hello")
+        exec2("%sh\nFOO=hello\necho $FOO", pattern="hello")
 
     def test_direct_call(self, exec2):
-        exec2("sh('date +%Y-%m-%d')", html_pattern = '\d{4}-\d{2}-\d{2}')
+        exec2("sh('date +%Y-%m-%d')", pattern = '\d{4}-\d{2}-\d{2}')
 
     def test_capture_sh_01(self, exec2):
         exec2("%capture(stdout='output')\n%sh uptime")
@@ -41,13 +28,12 @@ class TestShMode:
         exec2("output", pattern="up.*user.*load average")
 
     def test_remember_settings_01(self, exec2):
-        exec2("%sh FOO='testing123'", html_pattern="monospace")
-
+        exec2("%sh FOO='testing123'")
     def test_remember_settings_02(self, exec2):
-        exec2("%sh echo $FOO", html_pattern="testing123")
+        exec2("%sh echo $FOO", pattern="^testing123\s+")
 
     def test_sh_display(self, execblob, image_file):
-        execblob("%sh display < " + str(image_file))
+        execblob("%sh display < " + str(image_file), want_html=False)
 
     def test_sh_autocomplete_01(self, exec2):
         exec2("%sh TESTVAR29=xyz")
@@ -63,22 +49,19 @@ class TestShMode:
         assert mesg['target'] == "$TESTV"
 
     def test_bad_command(self, exec2):
-        exec2("%sh xyz", html_pattern="command not found")
+        exec2("%sh xyz", pattern="command not found")
 
 class TestShDefaultMode:
     def test_start_sh(self, exec2):
         exec2("%default_mode sh")
     def test_start_sh2(self, exec2):
-        exec2("pwd")
-
-    def test_single_line(self, exec2):
-        exec2("pwd\n", html_pattern=">/")
+        exec2("pwd", pattern="^/project", expect_doctype=True)
 
     def test_multiline(self, exec2):
-        exec2("FOO=hello\necho $FOO", html_pattern="hello")
+        exec2("FOO=hello\necho $FOO", pattern="^hello")
 
     def test_date(self, exec2):
-        exec2("date +%Y-%m-%d", html_pattern = '\d{4}-\d{2}-\d{2}')
+        exec2("date +%Y-%m-%d", pattern = '^\d{4}-\d{2}-\d{2}')
 
     def test_capture_sh_01(self, exec2):
         exec2("%capture(stdout='output')\nuptime")
@@ -86,12 +69,12 @@ class TestShDefaultMode:
         exec2("%sage\noutput", pattern="up.*user.*load average")
 
     def test_remember_settings_01(self, exec2):
-        exec2("FOO='testing123'", html_pattern="monospace")
+        exec2("FOO='testing123'")
     def test_remember_settings_02(self, exec2):
-        exec2("echo $FOO", html_pattern="testing123")
+        exec2("echo $FOO", pattern="^testing123\s+")
 
     def test_sh_display(self, execblob, image_file):
-        execblob("display < " + str(image_file))
+        execblob("display < " + str(image_file), want_html=False)
 
     def test_sh_autocomplete_01(self, exec2):
         exec2("TESTVAR29=xyz")
@@ -128,7 +111,7 @@ class TestRDefaultMode:
 
 class TestOctaveMode:
     def test_start_octave(self, exec2):
-        exec2("%octave", html_pattern = "DOCTYPE HTML PUBLIC")
+        exec2("%octave", expect_doctype=True)
 
     def test_octave_calc(self, exec2):
         code = "%octave\nformat short\nairy(3,2)\nbeta(2,2)\nbetainc(0.2,2,2)\nbesselh(0,2)"
@@ -154,7 +137,24 @@ class TestOctaveDefaultMode:
     def test_octave_capture1(self, exec2):
         exec2("%default_mode octave")
     def test_octave_capture2(self, exec2):
-        exec2("%capture(stdout='output')\nx = [1,2]", html_pattern = "DOCTYPE HTML PUBLIC")
+        exec2("%capture(stdout='output')\nx = [1,2]", expect_doctype=True)
     def test_octave_capture3(self, exec2):
         exec2("%sage\nprint(output)", pattern = "   1   2")
+
+class TestJupyterModes:
+    # 'bash', 'ir', and 'octave' kernel tests above
+    def test_start_a3(self, exec2):
+        exec2('a3 = jupyter("anaconda3")', expect_doctype=True)
+
+    def test_issue_862(self, exec2):
+        exec2('%a3\nx=1\nprint("x = %s" % x)\nx','x = 1\n')
+
+    def test_sagamath(self, exec2):
+        exec2('sm = jupyter(\'sagemath\')\nsm(\'e^(i*pi)\')', output='-1', expect_doctype=True)
+
+    def test_julia1(self, exec2):
+        # julia kernel takes 8-12 sec to load
+        exec2('jlk=jupyter("julia")', expect_doctype=True)
+    def test_julia2(self, exec2):
+        exec2('%jlk\nquadratic(a, sqr_term, b) = (-b + sqr_term) / 2a\nquadratic(2.0, -2.0, -12.0)', '2.5')
 


### PR DESCRIPTION
Reference: #862.

Added pytest cases for
- #862 
- anaconda3 jupyter bridge
- julia jupyter bridge
- sagemath jupyter bridge

Put sage & sage_server timing tests at start of default test run because they are most robust about initial state of sage_server.

To run just the new tests:
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews_modes.py::TestJupyterModes
```

