### PR TITLE
webapp/markdown+mathjax: second attempt at fixing #112

### DIFF
--- a/src/smc-webapp/markdown.coffee
+++ b/src/smc-webapp/markdown.coffee
@@ -13,8 +13,6 @@ marked.setOptions
     smartypants : true
 
 exports.markdown_to_html = markdown_to_html = (s) ->
-    # render s to html (from markdown)
-    s = marked(s)
 
     # replace mathjax, which is delimited by $, $$, \( \), and \[ \]
     v = misc.parse_mathjax(s)
@@ -33,6 +31,11 @@ exports.markdown_to_html = markdown_to_html = (s) ->
     else
         has_mathjax = false
 
+    #console.log "markdown_to_html: before marked s:", s
+    # render s to html (from markdown)
+    s = marked(s)
+    #console.log "markdown_to_html: after marked s:", s
+
     # if there was any mathjax, put it back in the s
     if has_mathjax
         for i in [0...w.length]
@@ -40,7 +43,9 @@ exports.markdown_to_html = markdown_to_html = (s) ->
     else if '\$' in s
         has_mathjax = true # still need to parse it to turn \$'s to $'s.
 
-    return {s:s, has_mathjax:has_mathjax}
+    ret = {s:s, has_mathjax:has_mathjax}
+    #console.log "markdown_to_html.ret: ", ret
+    return ret
 
 opts =
     gfm_code  : true

--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -1379,6 +1379,7 @@ class SynchronizedWorksheet extends SynchronizedDocument2
                 t.html(x.s)
             else
                 t.html_noscript(x.s)
+            #console.log 'sagews:mesg.md, t:', t
             t.mathjax(hide_when_rendering:true)
             output.append(t)
             @process_html_output(t)


### PR DESCRIPTION
also covering cases where formulas are enclosed in _italic_, etc.

strings for testing markdown, the new case is a formula in markdown or bold, while also handling pre-tag escaping:

    1. **Lemma 4.** _There is an $n_0 > 0$ such that $a_n < 2^n$ for all $n > n_0$._

    1. **Lemma 4.** <i>There is an $n_0 > 0$ such that $a_n < 2^n$ for all $n > n_0$.</i>

    1. **foo** bar _italic start $a^b$ **this bold `not $9`** $a_b$_ end of italic

    1. bar **foo _abc $9^3$ `foo $9` $a^b$_ end** xyz

    1. bar **foo _abc $9^3$ ```foo $9``` $a^b$_ end** xyzt

    1. **foo $x^` y$ bar**

    1. _foo $x`y$ bar_

    1. `foo **$9` $a^b$ **bar**

old cases:

    $a^b$

    `Payment of $499`

    abc `text $ 123` abc

    abc `$a^b$` test

    <pre>
    $a^b$
    </pre>

    ```
    asdf $a^b$ asdf
    asdf
    ```

    <pre>
    $ cd ~
    $ mkdir apps
    </pre>

    ```
    $ nosetests pandas$
    ..........
    OK (SKIP=2)
    ```
    x `$abc` y

    payment of \$ab99

    payment of `\$ab $`

    payment of `\$999$`

    `foo $999`

and this one here, a final special case:

    $`$`$