### PR TITLE
webapp+raw_server: tell browsers to always download a file if it should be downloaded

### DIFF
--- a/src/smc-project/raw_server.coffee
+++ b/src/smc-project/raw_server.coffee
@@ -56,6 +56,12 @@ exports.start_raw_server = (opts) ->
             base = "#{base_url}/#{project_id}/raw/"
             winston.info("raw server: port=#{port}, host='#{host}', base='#{base}'")
 
+            raw_server.use base, (req, res, next) ->
+                # this middleware function has to come before the express.static server!
+                # it sets the content type to octet-stream (aka "download me") if URL query ?download exists
+                if req.query.download?
+                    res.setHeader('Content-Type', 'application/octet-stream')
+                return next()
             raw_server.use(base, express_index(home,  {hidden:true, icons:true}))
             raw_server.use(base, express.static(home, {hidden:true}))
 

--- a/src/smc-webapp/project.coffee
+++ b/src/smc-webapp/project.coffee
@@ -591,11 +591,8 @@ class ProjectPage
             timeout : 45
             cb      : undefined   # cb(err) when file download from browser starts -- instant since we use raw path
 
-        if misc.filename_extension(opts.path) == 'pdf'
-            # unfortunately, download_file doesn't work for pdf these days...
-            opts.auto = false
-
-        url = "#{window.smc_base_url}/#{@project_id}/raw/#{misc.encode_path(opts.path)}"
+        # appending ?download sets the content type to octet-stream -- see smc-project/raw_server.coffee
+        url = "#{window.smc_base_url}/#{@project_id}/raw/#{misc.encode_path(opts.path)}?download"
         if opts.auto
             download_file(url)
         else


### PR DESCRIPTION
fixes #982

testing:
* try it with a pdf or svg file
* webapp recompilation
* restart the project to pick up the modified `smc-project/raw_server.coffee` file