### PR TITLE
webapp/file listing: add download buttons that also support right-click → copy url

### DIFF
--- a/src/smc-webapp/project.coffee
+++ b/src/smc-webapp/project.coffee
@@ -595,11 +595,14 @@ class ProjectPage
             # unfortunately, download_file doesn't work for pdf these days...
             opts.auto = false
 
-        url = "#{window.smc_base_url}/#{@project_id}/raw/#{misc.encode_path(opts.path)}"
+        url = @download_href(opts.path)
         if opts.auto
             download_file(url)
         else
             window.open(url)
+
+    download_href: (path) =>
+        "#{window.smc_base_url}/#{@project_id}/raw/#{misc.encode_path(path)}"
 
 project_pages = {}
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -211,10 +211,12 @@ FileRow = rclass
                 </OverlayTrigger>
             </span>
 
+    fullpath : ->
+        misc.path_to_file(@props.current_path, @props.name)
+
     handle_click : (e) ->
-        fullpath = misc.path_to_file(@props.current_path, @props.name)
         @props.actions.open_file
-            path       : fullpath
+            path       : @fullpath()
             foreground : misc.should_open_in_foreground(e)
         @props.actions.set_file_search('')
 
@@ -225,6 +227,8 @@ FileRow = rclass
             backgroundColor : @props.color
             borderStyle     : 'solid'
             borderColor     : if @props.bordered then SAGE_LOGO_COLOR else @props.color
+
+        href_download = @props.actions.download_href(@fullpath())
 
         <Row style={row_styles} onClick={@handle_click} className={'noselect'}>
             <Col sm=2 xs=3>
@@ -241,7 +245,17 @@ FileRow = rclass
             </Col>
             <Col sm=4 smPush=5 xs=6>
                 <TimeAgo date={(new Date(@props.time * 1000)).toISOString()} style={color:'#666'}/>
-                <span className='pull-right' style={color:'#666'}>{human_readable_size(@props.size)}</span>
+                <span className='pull-right' style={color:'#666'}>
+                    {human_readable_size(@props.size)}
+                    <Button style={marginLeft: '1em'}
+                            bsStyle='default'
+                            bsSize='xsmall'
+                            target='_blank'
+                            href="#{href_download}"
+                            onClick = {(e)->e.stopPropagation()}>
+                        {String.fromCharCode("8615")}
+                    </Button>
+                </span>
             </Col>
             <Col sm=5 smPull=4 xs=12>
                 {@render_name()}

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -553,6 +553,9 @@ class ProjectActions extends Actions
             files  : opts.path
         @_project().download_file(opts)
 
+    download_href : (path) ->
+        @_project().download_href(path)
+
     # This is the absolute path to the file with given name but with the
     # given extension added to the file (e.g., "md") if the file doesn't have
     # that extension.  If the file contains invalid characters this function


### PR DESCRIPTION
This is a simple solution for all issues related to #328 

Note, that it also support right-click and "copy url", since it is in the href of an anchor.

What I haven't done is to think much about the styling (we could add a hover text), nor if this also shows up for public file listing (would it work there?). Still, I like it, it's very minimal and it doesn't add much clutter.

It also definitely conflicts with my recent PR #983 since it moves that raw URL creation into a separate function ... merging is trivial, though.

