### PR TITLE
show_identifiers() #63

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2969,6 +2969,8 @@ def reset(vars=None, attached=False):
     sage.misc.reset.reset_interfaces()
     if attached:
         sage.misc.reset.reset_attached()
+    # reset() adds 'pretty_print' and 'view' to show_identifiers()
+    exec('sage.misc.session.state_at_init = dict(globals())',salvus.namespace)
 
 reset.__doc__ += sage.misc.reset.reset.__doc__
 
@@ -3780,3 +3782,16 @@ def search_doc(str):
     '<a href="https://www.google.com/search?q=site%3Adoc.sagemath.org+' + \
     str + '&oq=site%3Adoc.sagemath.org">'+str+'</a>'
     salvus.html(txt)
+
+import sage.misc.session
+def show_identifiers():
+    """
+    Returns a list of all variable names that have been defined during this session.
+
+    SMC introduces worksheet variables, including 'smc','salvus', and 'require'.
+    These are filtered from the list of variables returned by sage.misc.session.show_identifiers()
+    """
+    si =  eval('sage.misc.session.show_identifiers()',salvus.namespace)
+    # 'sage_salvus' is added when SMC reset() runs
+    si2 = [v for v in si if v not in ['smc','salvus','require','sage_salvus']]
+    return si2

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2970,6 +2970,8 @@ def reset(vars=None, attached=False):
     if attached:
         sage.misc.reset.reset_attached()
     # reset() adds 'pretty_print' and 'view' to show_identifiers()
+    # user can shadow these and they will appear in show_identifiers()
+    # 'sage_salvus' is added when the following line runs; user may not shadow it
     exec('sage.misc.session.state_at_init = dict(globals())',salvus.namespace)
 
 reset.__doc__ += sage.misc.reset.reset.__doc__
@@ -3788,10 +3790,10 @@ def show_identifiers():
     """
     Returns a list of all variable names that have been defined during this session.
 
-    SMC introduces worksheet variables, including 'smc','salvus', and 'require'.
-    These are filtered from the list of variables returned by sage.misc.session.show_identifiers()
+    SMC introduces worksheet variables, including 'smc','salvus', 'require', and after reset(), 'sage_salvus'.
+    These identifiers are removed from the output of sage.misc.session.show_identifiers() on return.
+    User should not assign to these variables when running code in a worksheet.
     """
     si =  eval('sage.misc.session.show_identifiers()',salvus.namespace)
-    # 'sage_salvus' is added when SMC reset() runs
     si2 = [v for v in si if v not in ['smc','salvus','require','sage_salvus']]
     return si2

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3794,6 +3794,7 @@ def show_identifiers():
     These identifiers are removed from the output of sage.misc.session.show_identifiers() on return.
     User should not assign to these variables when running code in a worksheet.
     """
-    si =  eval('sage.misc.session.show_identifiers()',salvus.namespace)
+    si =  eval('show_identifiers.fn()',salvus.namespace)
     si2 = [v for v in si if v not in ['smc','salvus','require','sage_salvus']]
     return si2
+show_identifiers.fn = sage.misc.session.show_identifiers

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1409,6 +1409,8 @@ def execute(conn, id, code, data, cell_id, preparse, message_queue):
         else:
             sys.stdout.flush(done=salvus._done)
         (sys.stdout, sys.stderr) = streams
+# execute.count goes from 0 to 2
+# used for show_identifiers()
 execute.count = 0
 
 

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -934,6 +934,9 @@ class Salvus(object):
         except:
             log("Error - unable to import sage.repl.interpreter")
 
+        import sys
+        import sage.misc.session
+
         for start, stop, block in blocks:
             # if import sage.repl.interpreter fails, sag_repl_interpreter is unreferenced
             try:
@@ -954,6 +957,14 @@ class Salvus(object):
                     self.code(source = p['result'], mode = "text/x-rst")
                 else:
                     reload_attached_files_if_mod_smc()
+                    if execute.count < 2:
+                        execute.count += 1
+                        if execute.count == 2:
+                            # this fixup has to happen after first block has executed (os.chdir etc)
+                            # but before user assigns any variable in worksheet
+                            # sage.misc.session.init() is not called until first call of show_identifiers
+                            block2 = "_=sage.misc.session.show_identifiers();sage.misc.session.state_at_init = dict(globals())\n"
+                            exec compile(block2, '', 'single') in namespace, locals
                     exec compile(block+'\n', '', 'single') in namespace, locals
                 sys.stdout.flush()
                 sys.stderr.flush()
@@ -1398,6 +1409,7 @@ def execute(conn, id, code, data, cell_id, preparse, message_queue):
         else:
             sys.stdout.flush(done=salvus._done)
         (sys.stdout, sys.stderr) = streams
+execute.count = 0
 
 
 def drop_privileges(id, home, transient, username):
@@ -1771,7 +1783,7 @@ def serve(port, host, extra_imports=False):
                      'hide', 'hideall', 'cell', 'fork', 'exercise', 'dynamic', 'var','jupyter',
                      'reset', 'restore', 'md', 'load', 'attach', 'runfile', 'typeset_mode', 'default_mode',
                      'sage_chat', 'fortran', 'modes', 'go', 'julia', 'pandoc', 'wiki', 'plot3d_using_matplotlib',
-                     'mediawiki', 'help', 'raw_input', 'input',
+                     'mediawiki', 'help', 'raw_input', 'input','show_identifiers',
                      'clear', 'delete_last_output', 'sage_eval',
                      'search_doc','search_src', 'octave', 'license']:
             namespace[name] = getattr(sage_salvus, name)

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -366,6 +366,12 @@ def image_file(tmpdir_factory):
     make_img().savefig(str(fn))
     return fn
 
+@pytest.fixture(scope='session')
+def data_path(tmpdir_factory):
+    path = tmpdir_factory.mktemp("data")
+    path.ensure_dir()
+    return path
+
 @pytest.fixture()
 def exec2(request, sagews, test_id):
     r"""

--- a/src/smc_sagews/smc_sagews/tests/test_00_timing.py
+++ b/src/smc_sagews/smc_sagews/tests/test_00_timing.py
@@ -11,6 +11,41 @@ import os
 import time
 import signal
 
+class TestSageTiming:
+    r"""
+    These tests are to validate the test framework. They do not
+    run sage_server.
+    """
+    def test_basic_timing(self):
+        start = time.time()
+        os.system('sleep 1')
+        tick = time.time()
+        elapsed = tick - start
+        assert 1.0 == pytest.approx(elapsed, abs = 0.1)
+
+    def test_load_sage(self):
+        start = time.time()
+        # maybe put first load into fixture
+        os.system("echo '2+2' | /usr/local/bin/sage -python")
+        tick = time.time()
+        elapsed = tick - start
+        print("elapsed 1: %s"%elapsed)
+        # second load after things are cached
+        start = time.time()
+        os.system("echo '2+2' | /usr/local/bin/sage -python")
+        tick = time.time()
+        elapsed = tick - start
+        print("elapsed 2: %s"%elapsed)
+        assert elapsed < 2.0
+
+    def test_import_sage_server(self):
+        start = time.time()
+        os.system("echo 'import sage_server' | /usr/local/bin/sage -python")
+        tick = time.time()
+        elapsed = tick - start
+        print("elapsed %s"%elapsed)
+        assert elapsed < 10.0
+
 class TestStartSageServer:
     def test_2plus2_timing(self, test_id):
         import sys
@@ -101,38 +136,3 @@ class TestStartSageServer:
         assert elapsed < 8.0
 
         return
-
-class TestSageTiming:
-    r"""
-    These tests are to validate the test framework. They do not
-    run sage_server.
-    """
-    def test_basic_timing(self):
-        start = time.time()
-        os.system('sleep 1')
-        tick = time.time()
-        elapsed = tick - start
-        assert 1.0 == pytest.approx(elapsed, abs = 0.1)
-
-    def test_load_sage(self):
-        start = time.time()
-        # maybe put first load into fixture
-        os.system("echo '2+2' | /usr/local/bin/sage -python")
-        tick = time.time()
-        elapsed = tick - start
-        print("elapsed 1: %s"%elapsed)
-        # second load after things are cached
-        start = time.time()
-        os.system("echo '2+2' | /usr/local/bin/sage -python")
-        tick = time.time()
-        elapsed = tick - start
-        print("elapsed 2: %s"%elapsed)
-        assert elapsed < 2.0
-
-    def test_import_sage_server(self):
-        start = time.time()
-        os.system("echo 'import sage_server' | /usr/local/bin/sage -python")
-        tick = time.time()
-        elapsed = tick - start
-        print("elapsed %s"%elapsed)
-        assert elapsed < 10.0

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -70,3 +70,39 @@ class TestSearchSrc:
 
     def test_search_src_max_chars(self, execinteract):
         execinteract('search_src("full cremonadatabase", max_chars = 1000)')
+
+class TestIdentifiers:
+    """
+    see SMC issue #63
+    """
+    def test_ident_set_file_env(self, exec2):
+        """emulate initial code block sent from UI, needed for first show_identifiers"""
+        code = "os.chdir(salvus.data[\'path\']);__file__=salvus.data[\'file\']"
+        exec2(code)
+    def test_show_identifiers_initial(self, exec2):
+        exec2("show_identifiers()","[]\n")
+
+    def test_show_identifiers_vars(self, exec2):
+        code = dedent(r"""
+        k = ['a','b','c']
+        A = {'a':'foo','b':'bar','c':'baz'}
+        z = 99
+        sorted(show_identifiers())""")
+        exec2(code, "['A', 'k', 'z']\n")
+
+    def test_save_and_reset(self,exec2,data_path):
+        code = dedent(r"""
+        save_session('%s')
+        reset()
+        show_identifiers()""")%data_path.join('session').strpath
+        exec2(code,"[]\n")
+    def test_load_session1(self,exec2,data_path):
+        code = dedent(r"""
+        pretty_print = 8
+        view = 9
+        load_session('%s')
+        sorted(show_identifiers())""")%data_path.join('session').strpath
+        output = "['A', 'k', 'pretty_print', 'view', 'z']\n"
+        exec2(code,output)
+    def test_load_session2(self,exec2):
+        exec2("pretty_print,view","(8, 9)\n")

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -106,3 +106,10 @@ class TestIdentifiers:
         exec2(code,output)
     def test_load_session2(self,exec2):
         exec2("pretty_print,view","(8, 9)\n")
+
+    def test_redefine_sage(self,exec2):
+        code = dedent(r"""
+        reset()
+        sage=1
+        show_identifiers()""")
+        exec2(code,"['sage']\n")


### PR DESCRIPTION
Reference: #63 

Fix was tricky because
- I was only able to set sage.misc.session.state_at_init after first code block has executed
- sage.misc.session.init() is not called until first invocation of show_identifiers()
- need to set sage.misc.session.state_at_init before first user cell executes or risk missing variable assignments in that cell
- worksheet server adds 'smc', 'salvus', 'require', and sometimes other identifiers to session namespace - I made the requirements choice of removing these before returning show_identifiers() because user can't shadow them anyway.

Pytest cases have been added for show_identifiers(), reset(), save_session(), load_session(). To run just the new tests:
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews.py::TestIdentifiers
```