### PR TITLE
webapp/sagews: discarding empty strings when deserializing cell output -- related to #1012

### DIFF
--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -2415,11 +2415,15 @@ class SynchronizedWorksheetCell
 
     output: =>
         v = []
-        for x in @raw_output().slice(38).split(MARKERS.output)
-            try
-                v.push(misc.from_json(x))
-            catch
-                console.warn("unable to read json message in worksheet: #{x}")
+        raw = @raw_output()
+        if not raw?  # might return undefined, see above
+            return v
+        for x in raw.slice(38).split(MARKERS.output)
+            if x?.length > 0 # empty strings cause json deserialization problems (i.e. that warning below)
+                try
+                    v.push(misc.from_json(x))
+                catch
+                    console.warn("unable to read json message in worksheet: #{x}")
         return v
 
     _get_output: () =>


### PR DESCRIPTION
see #1012 ... not sure if this is a fix at all, it does at least handle all the corner cases and finishes fixing [this change from a while ago](https://github.com/sagemathinc/smc/commit/5215886c8352504f199e00cc402960dff7269518#diff-9d796ba4eb777e83c8f17a2169b073dbL2416)

So, the point is, this PR should go in asap, but I'm not sure if the story behind why #1012 came up in the first place is fixed by that.