### PR TITLE
webapp/css: <a role="button"> mouse should be a pointer, not arrow

### DIFF
--- a/src/smc-webapp/index.sass
+++ b/src/smc-webapp/index.sass
@@ -170,6 +170,9 @@ input[type="text"], select, input[type="email"], select, input[type="password"],
   background-color: #000000
   border-color: #000000
 
+a[role="button"]
+  cursor: pointer
+
 .tooltip
   font-size: 11px
 

--- a/src/smc-webapp/index.sass
+++ b/src/smc-webapp/index.sass
@@ -171,6 +171,7 @@ input[type="text"], select, input[type="email"], select, input[type="password"],
   border-color: #000000
 
 a[role="button"]
+  +disable-user-select
   cursor: pointer
 
 .tooltip


### PR DESCRIPTION
The "buttons" e.g. in the "files", "new", ... and open editors row aren't changing the mouse cursor to a pointer (only the text inside of them). this changes this for all anchors with the role "button".