### PR TITLE
sagews/jupyter: removing conv.convert from jupyter kernel initialization.

### DIFF
--- a/src/smc_pyutil/smc_pyutil/sagews2pdf.py
+++ b/src/smc_pyutil/smc_pyutil/sagews2pdf.py
@@ -198,6 +198,7 @@ site = 'https://cloud.sagemath.com'
 
 import argparse, base64, cPickle, json, os, shutil, sys, textwrap, HTMLParser, tempfile, urllib
 from uuid import uuid4
+from pprint import pprint
 
 def escape_path(s):
     # see http://stackoverflow.com/questions/946170/equivalent-javascript-functions-for-pythons-urllib-quote-and-urllib-unquote
@@ -429,7 +430,10 @@ class Cell(object):
             for x in w[1:]:
                 if x:
                     try:
-                        self.output.append(json.loads(x))
+                        x_json = json.loads(x)
+                        #pprint(self.input_uuid)
+                        #pprint(x_json)
+                        self.output.append(x_json)
                     except ValueError:
                         try:
                             print "**WARNING:** Unable to de-json '%s'"%x

--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -120,8 +120,6 @@ def _jkmagic(kernel_name, **kwargs):
     # linkify: little gimmik, translates URLs to anchor tags
     conv = Ansi2HTMLConverter(inline=True, linkify=True)
 
-    salvus.html(conv.convert(""))
-
     def hout(s, block = True, scroll = False):
         r"""
         wrapper for ansi conversion before displaying output


### PR DESCRIPTION
makes no sense (?) and if at all, it should be called with full=False. issue #959

test with the example given in the #959 ticket