### PR TITLE
webapp/files: adding duplicate functionality ...

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2014, William Stein
+#    Copyright (C) 2014 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -1712,3 +1712,22 @@ exports.path_to_tab = (name) ->
 # assumes a valid editor tab name...
 exports.tab_to_path = (name) ->
     name.substring(7)
+
+# suggest a new filename when duplicating it
+# 1. strip extension, split at '_' or '-' if it exists
+# try to parse a number, if it works, increment it, etc.
+exports.suggest_duplicate_filename = (name) ->
+    {name, ext} = exports.separate_file_extension(name)
+    idx_dash = name.lastIndexOf('-')
+    idx_under = name.lastIndexOf('_')
+    idx = exports.max([idx_dash, idx_under])
+    new_name = null
+    if idx > 0
+        [prfx, ending] = [name[...idx+1], name[idx+1...]]
+        num = parseInt(ending)
+        if not Number.isNaN(num)
+            new_name = "#{prfx}#{num+1}"
+    new_name ?= "#{name}-1"
+    if ext?.length > 0
+        new_name += ".#{ext}"
+    return new_name

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1234,3 +1234,17 @@ describe 'is_valid_email_address is', ->
     it "false for blabla", ->
         valid('blabla').should.be.false()
 
+describe 'suggest_duplicate_filename', ->
+    dup = misc.suggest_duplicate_filename
+    it "works with numbers", ->
+        dup('filename-1.test').should.be.eql 'filename-2.test'
+        dup('filename-99.test').should.be.eql 'filename-100.test'
+        dup('filename_001.test').should.be.eql 'filename_2.test'
+        dup('filename_99.test').should.be.eql 'filename_100.test'
+    it "works also without", ->
+        dup('filename-test').should.be.eql 'filename-test-1'
+        dup('filename-xxx.test').should.be.eql 'filename-xxx-1.test'
+        dup('bla').should.be.eql 'bla-1'
+        dup('foo.bar').should.be.eql 'foo-1.bar'
+    it "also works with weird corner cases", ->
+        dup('asdf-').should.be.eql 'asdf--1'

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -848,6 +848,7 @@ ProjectFilesActions = rclass
                     'compress'
                     'delete'
                     'rename'
+                    'duplicate'
                     'move'
                     'copy'
                     'share'
@@ -1114,7 +1115,7 @@ ProjectFilesActionBox = rclass
                 <Col sm=12>
                     <ButtonToolbar>
                         <Button bsStyle='info' onClick={=>@rename_or_duplicate_click()} disabled={not @valid_rename_input(single_item)}>
-                            <Icon name='pencil' /> {action_title} file
+                            <Icon name='pencil' /> {action_title} item
                         </Button>
                         <Button onClick={@cancel_action}>
                             Cancel

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2015, William Stein
+#    Copyright (C) 2015 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -52,6 +52,9 @@ exports.file_action_buttons = file_action_buttons =
         rename   :
             name : 'Rename'
             icon : 'pencil'
+        duplicate:
+            name : 'Duplicate'
+            icon : 'clone'
         move     :
             name : 'Move'
             icon : 'arrows'
@@ -820,8 +823,10 @@ ProjectFilesActions = rclass
 
     render_action_button : (name) ->
         obj = file_action_buttons[name]
+        get_basename = =>
+            misc.path_split(@props.checked_files?.first()).tail
         <Button
-            onClick={=>@props.actions.set_file_action(name)}
+            onClick={=>@props.actions.set_file_action(name, get_basename)}
             key={name} >
             <Icon name={obj.icon} /> <span className='hidden-sm'>{obj.name}...</span>
         </Button>
@@ -853,6 +858,7 @@ ProjectFilesActions = rclass
                     'download'
                     'delete'
                     'rename'
+                    'duplicate'
                     'move'
                     'copy'
                     'share'
@@ -913,7 +919,7 @@ ProjectFilesActionBox = rclass
         copy_destination_directory  : ''
         copy_destination_project_id : if @props.public_view then '' else @props.project_id
         move_destination            : ''
-        new_name                    : misc.path_split(@props.checked_files?.first()).tail
+        new_name                    : @props.new_name
         show_different_project      : @props.public_view
 
     pre_styles :
@@ -1037,12 +1043,18 @@ ProjectFilesActionBox = rclass
             </Row>
         </div>
 
-    rename_click : ->
+    rename_or_duplicate_click : () ->
         rename_dir = misc.path_split(@props.checked_files?.first()).head
         destination = ReactDOM.findDOMNode(@refs.new_name).value
-        @props.actions.move_files
-            src  : @props.checked_files.toArray()
-            dest : misc.path_to_file(rename_dir, destination)
+        switch @props.file_action
+            when 'rename'
+                @props.actions.move_files
+                    src  : @props.checked_files.toArray()
+                    dest : misc.path_to_file(rename_dir, destination)
+            when 'duplicate'
+                @props.actions.copy_files
+                    src  : @props.checked_files.toArray()
+                    dest : misc.path_to_file(rename_dir, destination)
         @props.actions.set_file_action()
         @props.actions.set_all_files_unchecked()
 
@@ -1068,8 +1080,13 @@ ProjectFilesActionBox = rclass
             return false
         return @state.new_name.trim() isnt misc.path_split(single_item).tail
 
-    render_rename : ->
+    render_rename_or_duplicate: () ->
         single_item = @props.checked_files.first()
+        action_title = switch @props.file_action
+                            when 'rename'
+                                'Rename'
+                            when 'duplicate'
+                                'Duplicate'
         <div>
             <Row>
                 <Col sm=5 style={color:'#666'}>
@@ -1084,7 +1101,7 @@ ProjectFilesActionBox = rclass
                             ref          = 'new_name'
                             key          = 'new_name'
                             type         = 'text'
-                            defaultValue = {misc.path_split(single_item).tail}
+                            defaultValue = {@state.new_name}
                             placeholder  = 'New file name...'
                             onChange     = {=>@setState(new_name : ReactDOM.findDOMNode(@refs.new_name).value)}
                             onKeyDown    = {@action_key}
@@ -1096,8 +1113,8 @@ ProjectFilesActionBox = rclass
             <Row>
                 <Col sm=12>
                     <ButtonToolbar>
-                        <Button bsStyle='info' onClick={@rename_click} disabled={not @valid_rename_input(single_item)}>
-                            <Icon name='pencil' /> Rename file
+                        <Button bsStyle='info' onClick={=>@rename_or_duplicate_click()} disabled={not @valid_rename_input(single_item)}>
+                            <Icon name='pencil' /> {action_title} file
                         </Button>
                         <Button onClick={@cancel_action}>
                             Cancel
@@ -1106,6 +1123,12 @@ ProjectFilesActionBox = rclass
                 </Col>
             </Row>
         </div>
+
+    render_rename: ->
+        @render_rename_or_duplicate()
+
+    render_duplicate: ->
+        @render_rename_or_duplicate()
 
     submit_action_rename: () ->
         single_item = @props.checked_files.first()
@@ -1729,6 +1752,7 @@ exports.ProjectFiles = rclass ({name}) ->
             selected_file_index : rtypes.number
             directory_listings  : rtypes.object
             get_displayed_listing : rtypes.func
+            new_name            : rtypes.string
 
     propTypes :
         project_id    : rtypes.string
@@ -1738,6 +1762,7 @@ exports.ProjectFiles = rclass ({name}) ->
     getDefaultProps : ->
         page_number : 0
         file_search : ''
+        new_name : ''
         selected_file_index : 0
         actions : redux.getActions(name) # TODO: Do best practices way
         redux   : redux
@@ -1807,6 +1832,7 @@ exports.ProjectFiles = rclass ({name}) ->
                 project_id    = {@props.project_id}
                 public_view   = {public_view}
                 file_map      = {file_map}
+                new_name      = {@props.new_name}
                 actions       = {@props.actions} />
         </Col>
 

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -581,12 +581,29 @@ class ProjectActions extends Actions
             checked_files : @get_store().get('checked_files').clear()
             file_action   : undefined
 
+    _suggest_duplicate_filename: (name) =>
+        store = @get_store()
+        files_in_dir = {}
+        # This will set files_in_dir to our current view of the files in the current
+        # directory (at least the visible ones) or do nothing in case we don't know
+        # anything about files (highly unlikely).  Unfortunately (for this), our
+        # directory listings are stored as (immutable) lists, so we have to make
+        # a map out of them.
+        store.get_directory_listings()?.get(store.get('current_path'))?.map (x) ->
+            files_in_dir[x.get('name')] = true
+            return
+        # This loop will keep trying new names until one isn't in the directory
+        while true
+            name = misc.suggest_duplicate_filename(name)
+            if not files_in_dir[name]
+                return name
+
     set_file_action : (action, get_basename) =>
         switch action
             when 'move'
                 @redux.getActions('projects').fetch_directory_tree(@project_id)
             when 'duplicate'
-                @setState(new_name : misc.suggest_duplicate_filename(get_basename()))
+                @setState(new_name : @_suggest_duplicate_filename(get_basename()))
             when 'rename'
                 @setState(new_name : misc.path_split(get_basename()).tail)
         @setState(file_action : action)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2015, William Stein
+#    Copyright (C) 2015 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -562,9 +562,14 @@ class ProjectActions extends Actions
             checked_files : @get_store().get('checked_files').clear()
             file_action   : undefined
 
-    set_file_action : (action) =>
-        if action == 'move'
-            @redux.getActions('projects').fetch_directory_tree(@project_id)
+    set_file_action : (action, get_basename) =>
+        switch action
+            when 'move'
+                @redux.getActions('projects').fetch_directory_tree(@project_id)
+            when 'duplicate'
+                @setState(new_name : misc.suggest_duplicate_filename(get_basename()))
+            when 'rename'
+                @setState(new_name : misc.path_split(get_basename()).tail)
         @setState(file_action : action)
 
     ensure_directory_exists: (opts) =>


### PR DESCRIPTION
addresses issue #378 by extending the rename feature and adding a suggestion function for new names

testing: check files named like `file-11.sagews` or `test.md` and click on the duplicate button.