### PR TITLE
Fix Rebuilding LaTeX Document on Save

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1360,8 +1360,11 @@ class CodeMirrorEditor extends FileEditor
         @_saving = true
         @save_button.icon_spin(start:true, delay:8000)
         @save (err) =>
+            # WARNING: As far as I can tell, this doesn't call FileEditor.save
             if err
                 alert_message(type:"error", message:"Error saving #{@filename} -- #{err}; please try later")
+            else
+                @emit('saved')
             @save_button.icon_spin(false)
             @_saving = false
         return false

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -717,6 +717,10 @@ exports.FileEditor = FileEditor
 
 ###############################################
 # Codemirror-based File Editor
+# Emits:
+#     - 'saved' : when the file is successfully saved by the user
+#     - 'show'  :
+#     - 'toggle-split-view' :
 ###############################################
 class CodeMirrorEditor extends FileEditor
     constructor: (@project_id, @filename, content, opts) ->

--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -40,6 +40,12 @@ class exports.LatexEditor extends editor.FileEditor
         latex_buttonbar = @element.find(".salvus-editor-latex-buttonbar")
         latex_buttonbar.show()
 
+        @latex_editor.on 'saved', () =>
+            @update_preview () =>
+                if @_current_page == 'pdf-preview'
+                    @preview_embed.update()
+            @spell_check()
+
         @latex_editor.syncdoc.on 'connect', () =>
             @preview.zoom_width = @load_conf().zoom_width
             @update_preview()
@@ -362,10 +368,13 @@ class exports.LatexEditor extends editor.FileEditor
     get_resolution: () =>
         return @preview.opts.resolution
 
-
+    # This function isn't called on save button click since
+    # the codemirror's save button is called...
     click_save_button: () =>
         @latex_editor.click_save_button()
 
+    # This function isn't called on save
+    # @latex_editor.save is called instead for some reason
     save: (cb) =>
         @latex_editor.save (err) =>
             cb?(err)


### PR DESCRIPTION
Fixes #1065. 

This is *not* clean and does *not* fit into the current framework snugly. No idea if this is acceptable or not since our next strategic plan is to redo the LaTeX editor in React anyways.