### PR TITLE
Fix correctly displaying timeago on render

### DIFF
--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -58,7 +58,7 @@
     "redux": "^3.6.0",
     "remarked": "^0.1.4",
     "three": "^0.78.0",
-    "timeago": "^1.5.2",
+    "timeago": "^1.5.3",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -278,7 +278,6 @@ class SynchronizedString extends AbstractSynchronizedDoc
 
 class SynchronizedDocument2 extends SynchronizedDocument
     constructor: (@editor, opts, cb) ->
-        window.syncdoc2 = @
         @opts = defaults opts,
             cursor_interval : 1000   # ignored below right now
             sync_interval   : 2000   # never send sync messages upstream more often than this

--- a/src/smc-webapp/tasks.coffee
+++ b/src/smc-webapp/tasks.coffee
@@ -699,7 +699,6 @@ class TaskList
         @display_undelete(task)
         @display_last_edited(task)
         @display_desc(task)
-
         task.changed = false
 
         if @readonly
@@ -759,6 +758,7 @@ class TaskList
                     where : {task_id : task.task_id}
 
             a = $("<span>").attr('title',d.toISOString()).timeago()
+            a.text($.timeago(d.toISOString()))
             task.element.find(".salvus-task-last-edited").empty().append(a)
 
     click_hashtag_in_desc: (event) =>
@@ -1154,6 +1154,7 @@ class TaskList
             d.setUTCMilliseconds(task.due_date)
             e.attr('title',d.toISOString()).timeago()
             e.attr('title',d.toISOString())
+            e.text($.timeago(d.toISOString()))
             if not task.done and d < new Date()
                 e.addClass("salvus-task-overdue")
         else


### PR DESCRIPTION
Fixes #1067 

Timeago would wait until next update to change the text. Added 2 lines to just make sure that we show timeago if there is a relevant date.