### PR TITLE
Fix assignment expansion state

### DIFF
--- a/src/smc-webapp/course/assignments_panel.cjsx
+++ b/src/smc-webapp/course/assignments_panel.cjsx
@@ -15,8 +15,12 @@ styles = require('./styles')
     BigTime, FoldersToolbar, StudentAssignmentInfo, StudentAssignmentInfoHeader} = require('./common')
 
 
-exports.AssignmentsPanel = rclass
+exports.AssignmentsPanel = rclass ({name}) ->
     displayName : "CourseEditorAssignments"
+
+    reduxProps :
+        "#{name}":
+            expanded_assignments : rtypes.immutable.Set
 
     propTypes :
         name            : rtypes.string.isRequired
@@ -56,6 +60,7 @@ exports.AssignmentsPanel = rclass
                     project_id={@props.project_id}  redux={@props.redux}
                     students={@props.students} user_map={@props.user_map}
                     name={@props.name}
+                    is_expanded={@props.expanded_assignments.has(x.assignment_id)}
                     />
 
     render_show_deleted : (num_deleted) ->
@@ -128,12 +133,12 @@ Assignment = rclass
         students   : rtypes.object.isRequired
         user_map   : rtypes.object.isRequired
         background : rtypes.string
+        is_expanded : rtypes.bool
 
     shouldComponentUpdate : (nextProps, nextState) ->
-        return @state != nextState or @props.assignment != nextProps.assignment or @props.students != nextProps.students or @props.user_map != nextProps.user_map or @props.background != nextProps.background
+        return @state != nextState or @props.assignment != nextProps.assignment or @props.students != nextProps.students or @props.user_map != nextProps.user_map or @props.background != nextProps.background or @props.is_expanded != nextProps.is_expanded
 
     getInitialState : ->
-        more : false
         confirm_delete : false
 
     render_due : ->
@@ -631,9 +636,9 @@ Assignment = rclass
         </span>
 
     render_assignment_title_link : ->
-        <a href='' onClick={(e)=>e.preventDefault();@setState(more:not @state.more)}>
+        <a href='' onClick={(e)=>e.preventDefault();@actions(@props.name).toggle_assignment_expansion(@props.assignment.get('assignment_id'))}>
             <Icon style={marginRight:'10px'}
-                  name={if @state.more then 'caret-down' else 'caret-right'} />
+                  name={if @props.is_expanded then 'caret-down' else 'caret-right'} />
             {@render_assignment_name()}
         </a>
 
@@ -650,10 +655,10 @@ Assignment = rclass
         </Row>
 
     render : ->
-        <Row style={if @state.more then styles.selected_entry else styles.entry}>
+        <Row style={if @props.is_expanded then styles.selected_entry else styles.entry}>
             <Col xs=12>
                 {@render_summary_line()}
-                {@render_more() if @state.more}
+                {@render_more() if @props.is_expanded}
             </Col>
         </Row>
 

--- a/src/smc-webapp/course/assignments_panel.cjsx
+++ b/src/smc-webapp/course/assignments_panel.cjsx
@@ -636,7 +636,7 @@ Assignment = rclass
         </span>
 
     render_assignment_title_link : ->
-        <a href='' onClick={(e)=>e.preventDefault();@actions(@props.name).toggle_assignment_expansion(@props.assignment.get('assignment_id'))}>
+        <a href='' onClick={(e)=>e.preventDefault();@actions(@props.name).toggle_item_expansion('assignment', @props.assignment.get('assignment_id'))}>
             <Icon style={marginRight:'10px'}
                   name={if @props.is_expanded then 'caret-down' else 'caret-right'} />
             {@render_assignment_name()}

--- a/src/smc-webapp/course/handouts_panel.cjsx
+++ b/src/smc-webapp/course/handouts_panel.cjsx
@@ -45,16 +45,21 @@ step_ready = (step, n) ->
         when 'handout'
             return ''
 
-exports.HandoutsPanel = rclass
+exports.HandoutsPanel = rclass ({name}) ->
+
     displayName : 'Course-editor-HandoutsPanel'
+
+    reduxProps :
+        "#{name}":
+            expanded_handouts : rtypes.immutable.Set
 
     propTypes :
         project_id   : rtypes.string.isRequired
-        all_handouts : rtypes.object.isRequired # Immutable map handout_id -> handout
-        students     : rtypes.object.isRequired # Immutable map student_id -> student
+        all_handouts : rtypes.immutable.Map.isRequired # handout_id -> handout
+        students     : rtypes.immutable.Map.isRequired # student_id -> student
         user_map     : rtypes.object.isRequired
         actions      : rtypes.object.isRequired
-        store        : rtypes.object.isRequired
+        store_object : rtypes.object
         project_actions : rtypes.object.isRequired
 
     getInitialState : ->
@@ -63,7 +68,7 @@ exports.HandoutsPanel = rclass
 
     # Update on different students, handouts, or filter parameters
     shouldComponentUpdate : (nextProps, nextState) ->
-        if nextProps.all_handouts != @props.all_handouts or nextProps.students != @props.students
+        if nextProps.all_handouts != @props.all_handouts or nextProps.students != @props.students or @props.expanded_handouts != nextProps.expanded_handouts
             return true
         if nextState.search != @state.search or nextState.show_deleted != @state.show_deleted
             return true
@@ -132,7 +137,9 @@ exports.HandoutsPanel = rclass
                 <Handout backgroundColor={if i%2==0 then "#eee"}  key={handout.handout_id}
                         handout={@props.all_handouts.get(handout.handout_id)} project_id={@props.project_id}
                         students={@props.students} user_map={@props.user_map} actions={@props.actions}
-                        store={@props.store} open_directory={@props.project_actions.open_directory}
+                        store_object={@props.store_object} open_directory={@props.project_actions.open_directory}
+                        is_expanded={@props.expanded_handouts.has(handout.handout_id)}
+                        name={@props.name}
                 />}
             {@render_show_deleted_button(num_deleted) if num_deleted > 0}
         </Panel>
@@ -152,14 +159,15 @@ exports.HandoutsPanel.Header = rclass
 
 Handout = rclass
     propTypes :
+        name                : rtypes.string
         handout             : rtypes.object
         backgroundColor     : rtypes.string
-        store               : rtypes.object
+        store_object        : rtypes.object
         actions             : rtypes.object
         open_directory      : rtypes.func     # open_directory(path)
+        is_expanded         : rtypes.bool
 
     getInitialState : ->
-        more : false
         confirm_delete : false
 
     open_handout_path : (e)->
@@ -318,7 +326,7 @@ Handout = rclass
             <Col sm=12>
                 <Panel header={@render_more_header()}>
                     <StudentListForHandout handout={@props.handout} students={@props.students}
-                        user_map={@props.user_map} store={@props.store}, actions={@props.actions}/>
+                        user_map={@props.user_map} store_object={@props.store_object} actions={@props.actions}/>
                     {@render_handout_notes()}
                 </Panel>
             </Col>
@@ -330,15 +338,15 @@ Handout = rclass
         paddingBottom : '4px'
 
     render : ->
-        status = @props.store.get_handout_status(@props.handout)
-        <Row style={if @state.more then styles.selected_entry else styles.entry}>
+        status = @props.store_object.get_handout_status(@props.handout)
+        <Row style={if @props.is_expanded then styles.selected_entry else styles.entry}>
             <Col xs=12>
                 <Row key='summary' style={backgroundColor:@props.backgroundColor}>
                     <Col md=2 style={paddingRight:'0px'}>
                         <h5>
-                            <a href='' onClick={(e)=>e.preventDefault();@setState(more:not @state.more)}>
+                            <a href='' onClick={(e)=>e.preventDefault();@actions(@props.name).toggle_item_expansion('handout', @props.handout.get('handout_id'))}>
                                 <Icon style={marginRight:'10px'}
-                                      name={if @state.more then 'caret-down' else 'caret-right'} />
+                                      name={if @props.is_expanded then 'caret-down' else 'caret-right'} />
                                 <span>
                                     {misc.trunc_middle(@props.handout.get('path'), 80)}
                                     {<b> (deleted)</b> if @props.handout.get('deleted')}
@@ -368,17 +376,17 @@ Handout = rclass
                         </Row>
                     </Col>
                 </Row>
-                {@render_more() if @state.more}
+                {@render_more() if @props.is_expanded}
             </Col>
         </Row>
 
 StudentListForHandout = rclass
     propTypes :
-        user_map : rtypes.object
-        students : rtypes.object
-        handout : rtypes.object
-        store    : rtypes.object
-        actions  : rtypes.object
+        user_map     : rtypes.object
+        students     : rtypes.object
+        handout      : rtypes.object
+        store_object : rtypes.object
+        actions      : rtypes.object
 
     render_students : ->
         v = course_funcs.immutable_to_list(@props.students, 'student_id')
@@ -404,8 +412,8 @@ StudentListForHandout = rclass
         <StudentHandoutInfo
             key = {id}
             actions = {@props.actions}
-            info = {@props.store.student_handout_info(id, @props.handout)}
-            title = {misc.trunc_middle(@props.store.get_student_name(id), 40)}
+            info = {@props.store_object.student_handout_info(id, @props.handout)}
+            title = {misc.trunc_middle(@props.store_object.get_student_name(id), 40)}
             student = {id}
             handout = {@props.handout}
         />

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -1769,7 +1769,7 @@ init_redux = (course_filename, redux, course_project_id) ->
             return info
 
     initial_store_state =
-        expanded_assignments : immutable.Set()
+        expanded_assignments : immutable.Set() # Set of assignment id's (string) which should be expanded
 
     redux.createStore(the_redux_name, CourseStore, initial_store_state)
 

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -287,6 +287,7 @@ init_redux = (course_filename, redux, course_project_id) ->
         # item_name should be one of
         # ['student', 'assignment', handout']
         toggle_item_expansion: (item_name, item_id) =>
+            console.log("Toggling a", item_name, "with id", item_id)
             store = get_store()
             return if not store?
             field_name = "expanded_#{item_name}s"
@@ -1918,7 +1919,8 @@ CourseEditor = rclass ({name}) ->
         if @props.redux? and @props.assignments? and @props.user_map? and @props.students?
             <HandoutsPanel actions={@props.redux.getActions(@props.name)} all_handouts={@props.handouts}
                 project_id={@props.project_id} user_map={@props.user_map} students={@props.students}
-                store={@props.redux.getStore(@props.name)} project_actions={@props.redux.getProjectActions(@props.project_id)}
+                store_object={@props.redux.getStore(@props.name)} project_actions={@props.redux.getProjectActions(@props.project_id)}
+                name={@props.name}
                 />
         else
             return <Loading />

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -283,6 +283,20 @@ init_redux = (course_filename, redux, course_project_id) ->
             @_update(set:{pay:pay}, where:{table:'settings'})
             @set_all_student_project_course_info(pay)
 
+        # Takes an item_name and the id of the time
+        # item_name should be one of
+        # ['student', 'assignment', handout']
+        toggle_item_expansion: (item_name, item_id) =>
+            store = get_store()
+            return if not store?
+            field_name = "expanded_#{item_name}s"
+            expanded_items = store.get(field_name)
+            if expanded_items.has(item_id)
+                adjusted = expanded_items.delete(item_id)
+            else
+                adjusted = expanded_items.add(item_id)
+            @setState("#{field_name}" : adjusted)
+
         # Students
         add_students: (students) =>
             # students = array of account_id or email_address
@@ -639,16 +653,6 @@ init_redux = (course_filename, redux, course_project_id) ->
             @_update
                 set   : {deleted: false}
                 where : {assignment_id: assignment.get('assignment_id'), table: 'assignments'}
-
-        toggle_assignment_expansion: (assignment_id) =>
-            store = get_store()
-            return if not store?
-            expanded_assignments = store.get('expanded_assignments')
-            if expanded_assignments.has(assignment_id)
-                adjusted = expanded_assignments.delete(assignment_id)
-            else
-                adjusted = expanded_assignments.add(assignment_id)
-            @setState(expanded_assignments : adjusted)
 
         set_grade: (assignment, student, grade) =>
             store = get_store()
@@ -1769,7 +1773,9 @@ init_redux = (course_filename, redux, course_project_id) ->
             return info
 
     initial_store_state =
-        expanded_assignments : immutable.Set() # Set of assignment id's (string) which should be expanded
+        expanded_students    : immutable.Set() # Set of student id's (string) which should be expanded on render
+        expanded_assignments : immutable.Set() # Set of assignment id's (string) which should be expanded on render
+        expanded_handouts    : immutable.Set() # Set of handout id's (string) which should be expanded on render
 
     redux.createStore(the_redux_name, CourseStore, initial_store_state)
 

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -640,6 +640,16 @@ init_redux = (course_filename, redux, course_project_id) ->
                 set   : {deleted: false}
                 where : {assignment_id: assignment.get('assignment_id'), table: 'assignments'}
 
+        toggle_assignment_expansion: (assignment_id) =>
+            store = get_store()
+            return if not store?
+            expanded_assignments = store.get('expanded_assignments')
+            if expanded_assignments.has(assignment_id)
+                adjusted = expanded_assignments.delete(assignment_id)
+            else
+                adjusted = expanded_assignments.add(assignment_id)
+            @setState(expanded_assignments : adjusted)
+
         set_grade: (assignment, student, grade) =>
             store = get_store()
             return if not store?
@@ -1758,7 +1768,10 @@ init_redux = (course_filename, redux, course_project_id) ->
             @_handout_status[handout_id] = info
             return info
 
-    redux.createStore(the_redux_name, CourseStore)
+    initial_store_state =
+        expanded_assignments : immutable.Set()
+
+    redux.createStore(the_redux_name, CourseStore, initial_store_state)
 
     synchronized_db
         project_id : course_project_id

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -32,8 +32,12 @@ show_hide_deleted_style =
     marginTop  : '20px'
     float      : 'right'
 
-exports.StudentsPanel = rclass
+exports.StudentsPanel = rclass ({name}) ->
     displayName : "CourseEditorStudents"
+
+    reduxProps :
+        "#{name}":
+            expanded_students : rtypes.immutable.Set
 
     propTypes :
         name        : rtypes.string.isRequired
@@ -286,6 +290,7 @@ exports.StudentsPanel = rclass
                      user_map={@props.user_map} redux={@props.redux} name={@props.name}
                      project_map={@props.project_map}
                      assignments={@props.assignments}
+                     is_expanded={@props.expanded_students.has(x.student_id)}
                      />
 
     render_show_deleted : (num_deleted) ->
@@ -333,18 +338,18 @@ Student = rclass
         project_map : rtypes.object.isRequired  # here entirely to cause an update when project activity happens
         assignments : rtypes.object.isRequired  # here entirely to cause an update when project activity happens
         background  : rtypes.string
+        is_expanded  : rtypes.bool
 
     shouldComponentUpdate : (nextProps, nextState) ->
-        return @state != nextState or @props.student != nextProps.student or @props.assignments != nextProps.assignments  or @props.project_map != nextProps.project_map or @props.user_map != nextProps.user_map or @props.background != nextProps.background
+        return @state != nextState or @props.student != nextProps.student or @props.assignments != nextProps.assignments  or @props.project_map != nextProps.project_map or @props.user_map != nextProps.user_map or @props.background != nextProps.background or @props.is_expanded != nextProps.is_expanded
 
     getInitialState : ->
-        more : false
         confirm_delete: false
 
     render_student : ->
-        <a href='' onClick={(e)=>e.preventDefault();@setState(more:not @state.more)}>
+        <a href='' onClick={(e)=>e.preventDefault();@actions(@props.name).toggle_item_expansion('student', @props.student.get('student_id'))}>
             <Icon style={marginRight:'10px'}
-                  name={if @state.more then 'caret-down' else 'caret-right'}/>
+                  name={if @props.is_expanded then 'caret-down' else 'caret-right'}/>
             {@render_student_name()}
         </a>
 
@@ -442,7 +447,7 @@ Student = rclass
             </div>
 
     render_delete_button : ->
-        if not @state.more
+        if not @props.is_expanded
             return
         if @state.confirm_delete
             return @render_confirm_delete()
@@ -553,7 +558,7 @@ Student = rclass
         <Row style={if @state.more then selected_entry_style else entry_style}>
             <Col xs=12>
                 {@render_basic_info()}
-                {@render_more_panel() if @state.more}
+                {@render_more_panel() if @props.is_expanded}
             </Col>
         </Row>
 


### PR DESCRIPTION
Persist the expansion state of assignments in the course management. 

Implemented with an `immutable.Set`. Does not propagate to other clients.

Without this change, expansion state of assignments is loss between unmounts which makes things like grading a lot slower.