### PR TITLE
Fix add credit card date UI

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -270,24 +270,24 @@ AddPaymentMethod = rclass
             return validate.invalid
 
     render_input_expiration : ->
-        <div style={marginBottom:'15px'}>
+        <div style={marginBottom:'15px', display:'flex'}>
             <FormGroup>
                 <FormControl
                     readOnly    = {@state.submitting}
                     className   = 'form-control'
-                    style       = {misc.merge({display:'inline', width:'5em'}, @style('exp_month'))}
+                    style       = {misc.merge({width:'5em'}, @style('exp_month'))}
                     placeholder = 'MM'
                     type        = 'text'
                     size        = '2'
                     onChange    = {(e)=>@set_input_info('exp_month', undefined, e.target.value)}
                 />
             </FormGroup>
-            <span> / </span>
+            <span style={fontSize:'22px', margin: '1px 5px'}> / </span>
             <FormGroup>
                 <FormControl
                     readOnly    = {@state.submitting}
                     className   = 'form-control'
-                    style       = {misc.merge({display:'inline', width:'5em'}, @style('exp_year'))}
+                    style       = {misc.merge({width:'5em'}, @style('exp_year'))}
                     placeholder = 'YY'
                     type        = 'text'
                     size        = '2'


### PR DESCRIPTION
Fixes #1088 Now correctly on the same line.

![add card](https://cloud.githubusercontent.com/assets/618575/19574395/f527f960-96be-11e6-96bf-a1216bd4f079.png)
