### PR TITLE
Change Account button to Sign in when not logged in

### DIFF
--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -62,9 +62,10 @@ Page = rclass
             file_use         : rtypes.immutable.Map
             get_notify_count : rtypes.func
         account :
-            first_name   : rtypes.string
-            last_name    : rtypes.string
+            first_name   : rtypes.string # Necessary for get_fullname
+            last_name    : rtypes.string # Necessary for get_fullname
             get_fullname : rtypes.func
+            user_type    : rtypes.string # Necessary for is_logged_in
             is_logged_in : rtypes.func
         support :
             show : rtypes.bool
@@ -81,17 +82,37 @@ Page = rclass
             name = misc.trunc_middle(@props.get_fullname(), 32)
         if not name.trim()
             name = "Account"
+
         return name
 
+    render_account_tab: ->
+        <NavTab
+            name='account'
+            label={@account_name()}
+            icon='cog'
+            actions={@actions('page')}
+            active_top_tab={@props.active_top_tab}
+        />
+
+    sign_in_tab_clicked: ->
+        if @props.active_top_tab == 'account'
+            @actions('page').sign_in()
+
+    render_sign_in_tab: ->
+        <NavTab
+            name='account'
+            label='Sign in'
+            icon='sign-in'
+            on_click={@sign_in_tab_clicked}
+            actions={@actions('page')}
+            active_top_tab={@props.active_top_tab}
+        />
+
     render_right_nav : ->
+        logged_in = @props.is_logged_in()
         <Nav id='smc-right-tabs-fixed' style={height:'41px', lineHeight:'20px', margin:'0', overflowY:'hidden'}>
-            <NavTab
-                name='account'
-                label={@account_name()}
-                icon='cog'
-                actions={@actions('page')}
-                active_top_tab={@props.active_top_tab}
-            />
+            {@render_account_tab() if logged_in}
+            {@render_sign_in_tab() if not logged_in}
             <NavTab name='about' label='About' icon='question-circle' actions={@actions('page')} active_top_tab={@props.active_top_tab} />
             <NavItem className='divider-vertical hidden-xs' />
             {<NavTab label='Help' icon='medkit' actions={@actions('page')} active_top_tab={@props.active_top_tab} on_click={=>redux.getActions('support').show(true)} /> if require('./customize').commercial}

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -133,6 +133,17 @@ class PageActions extends Actions
         else
             return
 
+    set_sign_in_func : (func) =>
+        @sign_in = func
+
+    remove_sign_in_func : =>
+        @sign_in = => false
+
+    # Expected to be overridden by functions above
+    sign_in : =>
+        false
+
+
 redux.createActions('page', PageActions)
 
 # FUTURE: Save entire state to database for #450, saved workspaces

--- a/src/smc-webapp/landing_page.cjsx
+++ b/src/smc-webapp/landing_page.cjsx
@@ -152,8 +152,15 @@ SignIn = rclass
         has_account : rtypes.bool
         xs          : rtypes.bool
 
+    componentDidMount : ->
+        @actions('page').set_sign_in_func(@sign_in)
+
+    componentWillUnmount : ->
+        @actions('page').remove_sign_in_func()
+
     sign_in : (e) ->
-        e.preventDefault()
+        if e?
+            e.preventDefault()
         @props.actions.sign_in(ReactDOM.findDOMNode(@refs.email).value, ReactDOM.findDOMNode(@refs.password).value)
 
     display_forgot_password : ->


### PR DESCRIPTION
Changes `Account` button in top nav menu to be a `Sign in` button when not logged in.

Clicking `Sign in` also tries to log in if you're on the
landing page. Thus any confusion caused by the text
on the screen is a moot point.

An open public file:
![open_public](https://cloud.githubusercontent.com/assets/618575/19577721/3b8be714-96cd-11e6-8424-050fb83d5634.png)

On the landing page with an open public file:
![landing](https://cloud.githubusercontent.com/assets/618575/19577722/3daaacf6-96cd-11e6-937f-6fbb0c3eedf8.png)

View after clicking the `Sign in` on the top nav:
![logged in](https://cloud.githubusercontent.com/assets/618575/19577772/7bab8a5c-96cd-11e6-89f5-1d01f27cc756.png)
