### PR TITLE
webapp: better error message when file does not exist or `open_files` is not defined

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -250,7 +250,7 @@ ProjectMainContent = ({project_id, project_name, active_tab_name, group, open_fi
             if open_files?.has(active_path)
                 {Editor, redux_name} = open_files.getIn([active_path, 'component'])
                 if not Editor?
-                    throw Error("Editor must be defined")
+                    throw Error("No editor defined")
                 # TODO: ideally name, path, project_id is all we pass down here to any editor
                 <Editor
                     path         = {active_path}
@@ -262,7 +262,7 @@ ProjectMainContent = ({project_id, project_name, active_tab_name, group, open_fi
                     path         = {active_path}
                 />
             else
-                <div>You should not be here! {active_tab_name}</div>
+                <div>The file <code>active_tab_name}</code> does not exist.</div>
 
 exports.ProjectPage = ProjectPage = rclass ({name}) ->
     displayName : 'ProjectPage'


### PR DESCRIPTION
issue #1078

This improves the error message a little bit, but the underlying problem is definitely deeper