### PR TITLE
sagews: directly update the builtin "_" just like the normal system wide displayhook does

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -3543,6 +3543,9 @@ def typeset_mode(on=True, display=True, **args):
             if isinstance(obj, tuple(TYPESET_MODE_EXCLUDES)):
                 displayhook(obj)
             else:
+                # replicate what _system_sys_displayhook does regarding '_'
+                import __builtin__
+                __builtin__._ = obj
                 show(obj, display=display)
         sys.displayhook = f
     else:


### PR DESCRIPTION
issue #445

testing is explained in the ticket, basically in a sagews: 

```
123
---
%typeset_mode true
---
321
---
_
[here should be 321, not 123]
```