### PR TITLE
one-click adding for single search result when adding a collaborator or student

### DIFF
--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -118,7 +118,7 @@ exports.StudentsPanel = rclass ({name}) ->
     add_selector_clicked : ->
         @setState(selected_option_nodes: ReactDOM.findDOMNode(@refs.add_select).selectedOptions)
 
-    add_selected_students : ->
+    add_selected_students : (options) ->
         emails = {}
         for x in @state.add_select
             if x.account_id?
@@ -126,8 +126,12 @@ exports.StudentsPanel = rclass ({name}) ->
         students = []
         selections = []
 
-        for option in @state.selected_option_nodes
-            selections.push(option.getAttribute('value'))
+        # first check, if no student is selected and there is just one in the list
+        if (not @state.selected_option_nodes? or @state.selected_option_nodes?.length == 0) and options?.length == 1
+            selections.push(options[0].key)
+        else
+            for option in @state.selected_option_nodes
+                selections.push(option.getAttribute('value'))
 
         for y in selections
             if misc.is_valid_uuid_string(y)
@@ -179,7 +183,7 @@ exports.StudentsPanel = rclass ({name}) ->
                 when 1 then "Add selected student"
                 else "Add #{nb_selected} students"
         disabled = options.length == 0 or (options.length >= 2 and nb_selected == 0)
-        <Button onClick={@add_selected_students} disabled={disabled}><Icon name='user-plus' /> {btn_text}</Button>
+        <Button onClick={=>@add_selected_students(options)} disabled={disabled}><Icon name='user-plus' /> {btn_text}</Button>
 
     render_error : ->
         ed = null

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -807,10 +807,14 @@ CollaboratorsSearch = rclass
     invite_collaborator : (account_id) ->
         @actions('projects').invite_collaborator(@props.project.get('project_id'), account_id)
 
-    add_selected : ->
+    add_selected : (select) ->
         @reset()
-        for option in @state.selected_entries
-            @invite_collaborator(option.getAttribute('value'))
+        # handle case, where just one name is listed → clicking on "add" would clear everything w/o inviting
+        if (not @state.selected_entries? or @state.selected_entries?.length == 0) and select?.length == 1
+            @invite_collaborator(select[0].account_id)
+        else
+            for option in @state.selected_entries
+                @invite_collaborator(option.getAttribute('value'))
 
     select_list_clicked : ->
         selected_names = ReactDOM.findDOMNode(@refs.select).selectedOptions
@@ -914,7 +918,7 @@ CollaboratorsSearch = rclass
                 when 1 then "Invite selected user"
                 else "Invite #{nb_selected} users"
         disabled = select.length == 0 or (select.length >= 2 and nb_selected == 0)
-        <Button onClick={@add_selected} disabled={disabled}><Icon name='user-plus' /> {btn_text}</Button>
+        <Button onClick={=>@add_selected(select)} disabled={disabled}><Icon name='user-plus' /> {btn_text}</Button>
 
 
     render : ->


### PR DESCRIPTION
issue #1117 

how to test:

1. search for a new collaborator and if there is just one name as a result, clicking on "add user" is enough (not clicking on the name to actually select it)

2. the same in the student panel of a course, i.e. search for a name and if there is just one result, clicking on the button is also enough