### PR TITLE
Fix browser tab title on project refresh

### DIFF
--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -90,7 +90,9 @@ class PageActions extends Actions
             else
                 redux.getProjectActions(key)?.push_state()
                 project_map = redux.getStore('projects').get('project_map')
-                set_window_title(project_map?.getIn([key, 'title']))
+                redux.getStore('projects').wait
+                    until : (store) => store.get('project_map')
+                    cb    : (err, project_map) => set_window_title(project_map.getIn([key, 'title']))
 
     show_connection : (shown) =>
         @setState(show_connection : shown)

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -89,14 +89,18 @@ class PageActions extends Actions
                 return
             else
                 redux.getProjectActions(key)?.push_state()
+                set_window_title("Loading")
                 redux.getStore('projects').wait
-                    until : (store) =>
+                    until   : (store) =>
                         title = store.getIn(['project_map', key, 'title'])
                         title ?= store.getIn(['public_project_titles', key])
+                        if title == ""
+                            return "Untitled Project"
                         if not title?
                             redux.getActions('projects').fetch_public_project_title(key)
                         return title
-                    cb    : (err, title) => set_window_title(title)
+                    timeout : 15
+                    cb      : (err, title) => set_window_title(title ? "")
 
     show_connection : (shown) =>
         @setState(show_connection : shown)

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -89,7 +89,7 @@ class PageActions extends Actions
                 return
             else
                 redux.getProjectActions(key)?.push_state()
-                set_window_title("Loading")
+                set_window_title("Loading Project")
                 redux.getStore('projects').wait
                     until   : (store) =>
                         title = store.getIn(['project_map', key, 'title'])

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -89,10 +89,14 @@ class PageActions extends Actions
                 return
             else
                 redux.getProjectActions(key)?.push_state()
-                project_map = redux.getStore('projects').get('project_map')
                 redux.getStore('projects').wait
-                    until : (store) => store.get('project_map')
-                    cb    : (err, project_map) => set_window_title(project_map.getIn([key, 'title']))
+                    until : (store) =>
+                        title = store.getIn(['project_map', key, 'title'])
+                        title ?= store.getIn(['public_project_titles', key])
+                        if not title?
+                            redux.getActions('projects').fetch_public_project_title(key)
+                        return title
+                    cb    : (err, title) => set_window_title(title)
 
     show_connection : (shown) =>
         @setState(show_connection : shown)

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -620,6 +620,7 @@ class ProjectsStore extends Store
                     break
         return v
 
+# WARNING: A lot of code relys on the assumption project_map is undefined until it is loaded from the server.
 init_store =
     project_map   : undefined   # when loaded will be an immutable.js map that is synchronized with the database
     open_projects : immutable.List()  # ordered list of open projects

--- a/src/smc-webapp/projects_nav.cjsx
+++ b/src/smc-webapp/projects_nav.cjsx
@@ -185,12 +185,12 @@ OpenProjectMenuItem = rclass
 
     render : ->
         title = @props.project_map?.getIn([@props.project_id, 'title'])
+        title ?= @props.public_project_titles?.get(@props.project_id)
         if not title?
-            title = @props.public_project_titles?.get(@props.project_id)
-            if not title?
-                # Ensure that at some point we'll have the title if possible (e.g., if public)
-                @actions('projects').fetch_public_project_title(@props.project_id)
-                return <Loading key={@props.project_id} />
+            # Ensure that at some point we'll have the title if possible (e.g., if public)
+            @actions('projects').fetch_public_project_title(@props.project_id)
+            return <Loading key={@props.project_id} />
+
         desc = misc.trunc(@props.project_map?.getIn([@props.project_id, 'description']) ? '', 128)
         project_state = @props.project_map?.getIn([@props.project_id, 'state', 'state'])
         icon = require('smc-util/schema').COMPUTE_STATES[project_state]?.icon ? 'bullhorn'


### PR DESCRIPTION
Fixes #1106 

If fetching the title times out, the browser tab will default to "SageMathCloud".

If the title is blank, the browser tab will read "Untitled Project  - SageMathCloud".

While fetching a public title, the browser tab will read "Loading Project - SageMathCloud"