### PR TITLE
Make project tabs just pile up next to each other

### DIFF
--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -149,7 +149,7 @@ Page = rclass
             width:'100vw'
             overflow:'auto'
 
-        use_dropdown_menu = $(window).width() - 550 < @props.open_projects.size * 120
+        use_dropdown_menu = $(window).width() - 550
 
         <div ref="page" style={style}>
             {<FileUsePageWrapper /> if @props.show_file_use}


### PR DESCRIPTION
Fixes #1085 

As @williamstein points out, this is consistent with behavior found in browser tabs.