### PR TITLE
Jupyter cleanup

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -153,15 +153,18 @@ class TestOctaveDefaultMode:
     def test_octave_capture3(self, exec2):
         exec2("%sage\nprint(output)", pattern = "   1   2")
 
-class TestJupyterModes:
-    # 'bash', 'ir', and 'octave' kernel tests above
+class TestAnaconda3Mode:
     def test_start_a3(self, exec2):
         exec2('a3 = jupyter("anaconda3")')
 
     def test_issue_862(self, exec2):
         exec2('%a3\nx=1\nprint("x = %s" % x)\nx','x = 1\n')
 
-    def test_sagamath(self, exec2):
+    def test_a3_errror(self, exec2):
+        exec2('%a3\nxyz*', html_pattern = 'span style.*color')
+
+class TestJupyterModes:
+    def test_sagemath(self, exec2):
         exec2('sm = jupyter(\'sagemath\')\nsm(\'e^(i*pi)\')', output='-1')
 
     def test_julia1(self, exec2):


### PR DESCRIPTION
- Use atexit and sage cleaner to kill jupyter client and kernel processes and subprocesses when sage client exits.
- Also fixes bug with ansi colors in stderr output seen with anaconda3. Test case added.
- Fix a couple typos.
 