### PR TITLE
compute server: limit the number of parallel state updates

### DIFF
--- a/src/smc-hub/compute-server.coffee
+++ b/src/smc-hub/compute-server.coffee
@@ -1135,7 +1135,7 @@ update_states = (cb) ->
                                 cb(err)
                             else
                                 project.state(update:true, cb:cb)
-            async.map(projects, f, cb)
+            async.mapLimit(projects, 20, f, cb)
         ], (err) ->
             setTimeout(update_states, 2*60*1000)
             cb?(err)


### PR DESCRIPTION
I think it's a sane move to limit this map a little bit, e.g. after restart or during high load. of course, if it takes longer than two minutes, we're in in any case in a gameover situation.