### PR TITLE
webapp/client: increasing max number of listeners of Client to 3000

### DIFF
--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -192,7 +192,11 @@ class exports.Connection extends EventEmitter
     #    - 'new_version', number -- sent when there is a new version of the source code so client should refresh
 
     constructor: (@url) ->
-        @setMaxListeners(300)  # every open file/table/sync db listens for connect event, which adds up.
+        # Tweaks the maximum number of listeners an EventEmitter can have -- 0 would mean unlimited
+        # The issue is https://github.com/sagemathinc/smc/issues/1098 and the errors we got are
+        # (node) warning: possible EventEmitter memory leak detected. 301 listeners added. Use emitter.setMaxListeners() to increase limit.
+        @setMaxListeners(3000)  # every open file/table/sync db listens for connect event, which adds up.
+
         @emit("connecting")
         @_id_counter       = 0
         @_sessions         = {}

--- a/src/smc-util/synctable.coffee
+++ b/src/smc-util/synctable.coffee
@@ -210,6 +210,7 @@ class SyncTable extends EventEmitter
 
         @_client.on('disconnected', disconnected)
         @_client_listeners.disconnected = disconnected
+        # console.log "synctable.SyncTable EventListeners.listenerCount('disconnected')", @_client.listenerCount('disconnected')
 
         return
 

--- a/src/webapp-lib.coffee
+++ b/src/webapp-lib.coffee
@@ -1,3 +1,5 @@
+# Library file for SMC webapp
+
 # These old-school JS files need to be on top, otherwise dependency issues arise
 # (e.g. minified jquery isn't properly being detected, etc.)
 


### PR DESCRIPTION
see issue #1098

I've tested this on a test course with 200 students. There, the 'disconnected' event alone has 411 listeners. Hence that new limit of 3000 is well above this.