### PR TITLE
sagews2pdf: no newline when inserting a graphic, then the latex is valid when there is an image inside an \href

### DIFF
--- a/src/smc_pyutil/smc_pyutil/sagews2pdf.py
+++ b/src/smc_pyutil/smc_pyutil/sagews2pdf.py
@@ -317,7 +317,7 @@ class Parser(HTMLParser.HTMLParser):
                     filename = base+'.pdf'
                 self._commands.append(c)
                 # the choice of 120 is "informed" but also arbitrary
-                self.result += '\\includegraphics[resolution=120]{%s}\n'%filename
+                self.result += '\\includegraphics[resolution=120]{%s}'%filename
             else:
                 # fallback, because there is no src='...'
                 self.result += '\\verbatim{image: %s}' % str(attrs)


### PR DESCRIPTION
issue #100

I also tested, if it converts some other sagews with images and that worked, too. seems to be a pretty safe fix.