### PR TITLE
Improve start/stop all student projects UI feedback

### DIFF
--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -513,7 +513,6 @@ init_redux = (course_filename, redux, course_project_id) ->
             else if action == 'stop'
                 @setState(action_all_projects_state : "stopping")
 
-
         set_all_student_project_titles: (title) =>
             actions = redux.getActions('projects')
             get_store()?.get_students().map (student, student_id) =>

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -503,7 +503,7 @@ init_redux = (course_filename, redux, course_project_id) ->
 
                 set_all_action_status("running")
                 opts =
-                    project_ids : student_project_ids
+                    project_ids : student_project_ids.toJS()
                     cb          : (err, res) => set_all_action_status(err ? "success")
                     timeout     : 6 * student_project_ids.size
 

--- a/src/smc-webapp/course/settings_panel.cjsx
+++ b/src/smc-webapp/course/settings_panel.cjsx
@@ -21,34 +21,38 @@ StudentProjectsStartStopPanel = rclass ({name}) ->
 
     reduxProps :
         "#{name}" :
-            action_all_projects_status : rtypes.immutable.Map
+            action_all_projects_state : rtypes.string
 
     propTypes :
         num_running_projects : rtypes.number
         num_students         : rtypes.number
 
     getDefaultProps : ->
-        action_all_projects_status : immutable.Map({})
+        action_all_projects_state : "any"
 
     getInitialState : ->
-        confirm_stop_all_projects       : false
-        confirm_start_all_projects      : false
+        confirm_stop_all_projects   : false
+        confirm_start_all_projects  : false
 
     render_in_progress_action : ->
-        action_name = @props.action_all_projects_status.get('action')
-        switch action_name
-            when "stop"
+        state_name = @props.action_all_projects_state
+        switch state_name
+            when "stopping"
+                if @props.num_running_projects == 0
+                    return
                 bsStyle = 'warning'
             else
+                if @props.num_running_projects == @props.num_students
+                    return
                 bsStyle = 'info'
 
         <Alert bsStyle=bsStyle>
-            {misc.capitalize(action_name)} all projects in progress... <Icon name='circle-o-notch' spin />
+            {misc.capitalize(state_name)} all projects... <Icon name='circle-o-notch' spin />
         </Alert>
 
     render_error_occurred : ->
         <Alert bsStyle='warning'>
-            {misc.capitalize(@props.action_all_projects_status.get('action'))} all projects timed out.
+            {misc.capitalize(@props.action_all_projects_state)}
             Please report error this if the problem persists.
         </Alert>
 
@@ -83,9 +87,6 @@ StudentProjectsStartStopPanel = rclass ({name}) ->
             </ButtonToolbar>
         </Alert>
 
-    disable_both_buttons : (r, n) ->
-        return n == 0 or @props.action_all_projects_status.get('status') == "running"
-
     render : ->
         r = @props.num_running_projects
         n = @props.num_students
@@ -99,12 +100,12 @@ StudentProjectsStartStopPanel = rclass ({name}) ->
                 <Col md=12>
                     <ButtonToolbar>
                         <Button onClick={=>@setState(confirm_start_all_projects:true)}
-                            disabled={@disable_both_buttons(r, n) or n==r or @state.confirm_start_all_projects}
+                            disabled={n==0 or n==r or @state.confirm_start_all_projects or @props.action_all_projects_state == "starting"}
                         >
                             <Icon name="flash"/> Start all...
                         </Button>
                         <Button onClick={=>@setState(confirm_stop_all_projects:true)}
-                            disabled={@disable_both_buttons(r, n) or r==0 or @state.confirm_stop_all_projects}
+                            disabled={n==0 or r==0 or @state.confirm_stop_all_projects or @props.action_all_projects_state == "stopping"}
                         >
                             <Icon name="hand-stop-o"/> Stop all...
                         </Button>
@@ -115,8 +116,7 @@ StudentProjectsStartStopPanel = rclass ({name}) ->
                 <Col md=12>
                     {@render_confirm_start_all_projects() if @state.confirm_start_all_projects}
                     {@render_confirm_stop_all_projects() if @state.confirm_stop_all_projects}
-                    {@render_in_progress_action() if @props.action_all_projects_status.get('status') == "running"}
-                    {@render_error_occurred() if @props.action_all_projects_status.get('status') == "timeout"}
+                    {@render_in_progress_action() if @props.action_all_projects_state != "any"}
                 </Col>
             </Row>
             <hr/>

--- a/src/smc-webapp/course/settings_panel.cjsx
+++ b/src/smc-webapp/course/settings_panel.cjsx
@@ -50,12 +50,6 @@ StudentProjectsStartStopPanel = rclass ({name}) ->
             {misc.capitalize(state_name)} all projects... <Icon name='circle-o-notch' spin />
         </Alert>
 
-    render_error_occurred : ->
-        <Alert bsStyle='warning'>
-            {misc.capitalize(@props.action_all_projects_state)}
-            Please report error this if the problem persists.
-        </Alert>
-
     render_confirm_stop_all_projects: ->
         <Alert bsStyle='warning'>
             Are you sure you want to stop all student projects (this might be disruptive)?

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -636,7 +636,7 @@ class ProjectsStore extends Store
 
     wait_until_projects_are_running : (opts) =>
         opts = defaults opts,
-            project_ids   : required  # Must have a .includes()
+            project_ids   : required # [Strings..]
             timeout       : 30
             cb            : undefined
         opts.desired_states = ["running"]
@@ -644,7 +644,7 @@ class ProjectsStore extends Store
 
     wait_until_projects_are_stopped : (opts) =>
         opts = defaults opts,
-            project_ids   : required  # Must have a .includes()
+            project_ids   : required # [Strings..]
             timeout       : 30
             cb            : undefined
         opts.desired_states = ["closed", "closing", "opened", "stopping"]
@@ -657,14 +657,19 @@ class ProjectsStore extends Store
             cb            : undefined
             desired_states : required
 
+        id_map = {}
+        for id in opts.project_ids
+            id_map[id] = true
+
         checker = (store) =>
             return store.get('project_map')
-                .filter (project, id) => opts.project_ids.includes(id)
+                .filter (project, id) => id_map[id]
                 .every (project) => project.getIn(['state', 'state']) in opts.desired_states
         @wait
-            until   : underscore.throttle(checker, 500)
-            timeout : opts.timeout
-            cb      : opts.cb
+            until    : checker
+            throttle : 500
+            timeout  : opts.timeout
+            cb       : opts.cb
 
 
 # WARNING: A lot of code relies on the assumption project_map is undefined until it is loaded from the server.

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -634,44 +634,6 @@ class ProjectsStore extends Store
                     break
         return v
 
-    wait_until_projects_are_running : (opts) =>
-        opts = defaults opts,
-            project_ids   : required # [Strings..]
-            timeout       : 30
-            cb            : undefined
-        opts.desired_states = ["running"]
-        @_wait_until_projects_are_one_of_states(opts)
-
-    wait_until_projects_are_stopped : (opts) =>
-        opts = defaults opts,
-            project_ids   : required # [Strings..]
-            timeout       : 30
-            cb            : undefined
-        opts.desired_states = ["closed", "closing", "opened", "stopping"]
-        @_wait_until_projects_are_one_of_states(opts)
-
-    _wait_until_projects_are_one_of_states : (opts) =>
-        opts = defaults opts,
-            project_ids   : required
-            timeout       : 30
-            cb            : undefined
-            desired_states : required
-
-        id_map = {}
-        for id in opts.project_ids
-            id_map[id] = true
-
-        checker = (store) =>
-            return store.get('project_map')
-                .filter (project, id) => id_map[id]
-                .every (project) => project.getIn(['state', 'state']) in opts.desired_states
-        @wait
-            until    : checker
-            throttle : 500
-            timeout  : opts.timeout
-            cb       : opts.cb
-
-
 # WARNING: A lot of code relies on the assumption project_map is undefined until it is loaded from the server.
 init_store =
     project_map   : undefined   # when loaded will be an immutable.js map that is synchronized with the database

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -6,6 +6,7 @@ Question: can we use redux to implement the same API as r.cjsx exports (which wa
 
 async = require('async')
 immutable = require('immutable')
+underscore = require('underscore')
 
 React = require('react')
 
@@ -81,9 +82,12 @@ class Store extends EventEmitter
     # happens call the given callback.
     wait: (opts) =>
         opts = defaults opts,
-            until   : required     # waits until "until(store)" evaluates to something truthy
-            timeout : 30           # in seconds -- set to 0 to disable (DANGEROUS since until will get run for a long time)
-            cb      : required     # cb(undefined, until(store)) on success and cb('timeout') on failure due to timeout
+            until    : required     # waits until "until(store)" evaluates to something truthy
+            throttle : undefined    # in ms -- throttles the call to until(store)
+            timeout  : 30           # in seconds -- set to 0 to disable (DANGEROUS since until will get run for a long time)
+            cb       : required     # cb(undefined, until(store)) on success and cb('timeout') on failure due to timeout
+        if throttle?
+            opts.until = underscore.throttle(opts.until, throttle)
         # Do a first check to see if until is already true
         x = opts.until(@)
         if x

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -82,12 +82,12 @@ class Store extends EventEmitter
     # happens call the given callback.
     wait: (opts) =>
         opts = defaults opts,
-            until    : required     # waits until "until(store)" evaluates to something truthy
-            throttle : undefined    # in ms -- throttles the call to until(store)
-            timeout  : 30           # in seconds -- set to 0 to disable (DANGEROUS since until will get run for a long time)
-            cb       : required     # cb(undefined, until(store)) on success and cb('timeout') on failure due to timeout
-        if throttle?
-            opts.until = underscore.throttle(opts.until, throttle)
+            until       : required     # waits until "until(store)" evaluates to something truthy
+            throttle_ms : undefined    # in ms -- throttles the call to until(store)
+            timeout     : 30           # in seconds -- set to 0 to disable (DANGEROUS since until will get run for a long time)
+            cb          : required     # cb(undefined, until(store)) on success and cb('timeout') on failure due to timeout
+        if opts.throttle_ms?
+            opts.until = underscore.throttle(opts.until, opts.throttle_ms)
         # Do a first check to see if until is already true
         x = opts.until(@)
         if x

--- a/src/smc-webapp/users.cjsx
+++ b/src/smc-webapp/users.cjsx
@@ -32,20 +32,21 @@ immutable = require('immutable')
 # Register the actions
 class UsersActions extends Actions
     fetch_non_collaborator: (account_id) =>
-        salvus_client.get_usernames
-            account_ids : [account_id]
-            use_cache   : false
-            cb          : (err, x) =>
-                if err
-                    console.warn("ERROR getting username for account with id '#{account_id}'")
-                else
-                    obj = x[account_id]
-                    if obj?
-                        obj.account_id = account_id
-                        user_map = store.get('user_map')
-                        if user_map? and not user_map.get(account_id)?
-                            user_map = user_map.set(account_id, immutable.fromJS(obj))
-                            @setState(user_map : user_map)
+        if account_id?
+            salvus_client.get_usernames
+                account_ids : [account_id]
+                use_cache   : false
+                cb          : (err, x) =>
+                    if err
+                        console.warn("ERROR getting username for account with id '#{account_id}'")
+                    else
+                        obj = x[account_id]
+                        if obj?
+                            obj.account_id = account_id
+                            user_map = store.get('user_map')
+                            if user_map? and not user_map.get(account_id)?
+                                user_map = user_map.set(account_id, immutable.fromJS(obj))
+                                @setState(user_map : user_map)
 
 actions = redux.createActions('users', UsersActions)
 

--- a/src/smc-webapp/users.cjsx
+++ b/src/smc-webapp/users.cjsx
@@ -32,21 +32,22 @@ immutable = require('immutable')
 # Register the actions
 class UsersActions extends Actions
     fetch_non_collaborator: (account_id) =>
-        if account_id?
-            salvus_client.get_usernames
-                account_ids : [account_id]
-                use_cache   : false
-                cb          : (err, x) =>
-                    if err
-                        console.warn("ERROR getting username for account with id '#{account_id}'")
-                    else
-                        obj = x[account_id]
-                        if obj?
-                            obj.account_id = account_id
-                            user_map = store.get('user_map')
-                            if user_map? and not user_map.get(account_id)?
-                                user_map = user_map.set(account_id, immutable.fromJS(obj))
-                                @setState(user_map : user_map)
+        if not account_id?
+            return
+        salvus_client.get_usernames
+            account_ids : [account_id]
+            use_cache   : false
+            cb          : (err, x) =>
+                if err
+                    console.warn("ERROR getting username for account with id '#{account_id}'")
+                else
+                    obj = x[account_id]
+                    if obj?
+                        obj.account_id = account_id
+                        user_map = store.get('user_map')
+                        if user_map? and not user_map.get(account_id)?
+                            user_map = user_map.set(account_id, immutable.fromJS(obj))
+                            @setState(user_map : user_map)
 
 actions = redux.createActions('users', UsersActions)
 


### PR DESCRIPTION
Edit:
Removed `wait until` madness.  
Now tries for 5 minutes to keep all projects running or closed. 
Clicking the other option while this happens removes the timeout and interval of the previous action.

### After clicking `Start...`.

![start](https://cloud.githubusercontent.com/assets/618575/19788056/188a2c56-9c5b-11e6-88ac-90e2bcbc1c48.png)

### After clicking `Start All`.

![starting](https://cloud.githubusercontent.com/assets/618575/19788057/1a02ec12-9c5b-11e6-8b49-b9f9a1056665.png)

### After clicking `Stop All` similar to above.
![stopping](https://cloud.githubusercontent.com/assets/618575/19788059/1af9f89a-9c5b-11e6-9d59-d8a0fb884211.png)