### PR TITLE
webapp: md and latex editor render tweaks: preview no longer does not overlaps with buttons, fixing margin and offset computations, triggering recalc on latex building, some style cleanup.

### DIFF
--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -142,7 +142,10 @@
   background-color : #eee
   overflow-x       : auto
   overflow-y       : scroll
-  border-left      : 2px solid #ddd
+
+.salvus-editor-pdf-preview-page-single
+  text-align       : center
+  min-height       : 3em
 
 .salvus-editor-pdf-preview-image
   margin           : 1em
@@ -175,6 +178,7 @@
 .salvus-editor-pdf-preview-buttons
   position     : absolute
   margin-right : 1em
+  padding-top  : 2px
   right        : 0
   font-size    : 11pt
 
@@ -562,31 +566,22 @@ code
 .salvus-editor-resize-bar-layout-1
   height     : 6px
   cursor     : ns-resize
-  background : #efefef
+  background : #ccc
   &:hover
-    background : #ddd
+    background : #999
 
-.salvus-editor-resize-bar-layout-2, .salvus-editor-latex-resize-bar
+.salvus-editor-resize-bar-layout-2, .salvus-editor-latex-resize-bar, .salvus-editor-html-md-resize-bar
   cursor     : ew-resize
-  background : #efefef
+  background : #ccc
   width      : 6px
   &:hover
-    background : #ddd
-
-.salvus-editor-resize-bar-layout-2, .salvus-editor-html-md-resize-bar
-  cursor     : ew-resize
-  background : #efefef
-  width      : 6px
-  &:hover
-    background : #ddd
+    background : #999
 
 .salvus-editor-html-md-preview
-  border     : 1px solid lightgrey
   padding    : 12px
   background : white
   position   : absolute
   overflow   : auto
-  margin-top : -10px   // horrible temporary hack
 
 .smc-html-selection
   background-color : lightgrey

--- a/src/smc-webapp/editor-html-md/editor-html-md.coffee
+++ b/src/smc-webapp/editor-html-md/editor-html-md.coffee
@@ -1,6 +1,25 @@
-#############################################
+##############################################################################
+#
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2014--2016, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
 # Editor for HTML/Markdown/ReST documents
-#############################################
+##############################################################################
 
 _               = require('underscore')
 async           = require('async')
@@ -18,9 +37,7 @@ editor          = require('../editor')
 
 {redux}         = require('../smc-react')
 
-
 templates       = $("#salvus-editor-templates")
-
 
 class exports.HTML_MD_Editor extends editor.FileEditor
     constructor: (@project_id, @filename, content, @opts) ->
@@ -617,9 +634,9 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             width = chat_pos.left
 
         {top, left} = @element.offset()
-        editor_width = (width - left)*@_split_pos
+        editor_width = (width - left) * @_split_pos
 
-        @_dragbar.css('left',editor_width+left)
+        @_dragbar.css('left', editor_width + left)
 
         # console.log("@source_editor.show: top=#{top} + @edit_buttons.height()=#{@edit_buttons.height()}")
 
@@ -627,13 +644,16 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             width : editor_width
             top   : top + @edit_buttons.height()
 
-        button_bar_height = @element.find(".salvus-editor-codemirror-button-container").height()
+        button_bar_height = @element.find(".salvus-editor-codemirror-button-row").height()
         @element.maxheight(offset:button_bar_height)
         @preview.maxheight(offset:button_bar_height)
 
+        # offset from the top of the container for the preview on the right and the dragbar
+        top_offset = @edit_buttons.height() + button_bar_height + 2
+
         @_dragbar.height(@source_editor.element.height())
         @_dragbar.offset(top: @source_editor.element.offset() + button_bar_height)
-        @_dragbar.css('top', "#{@edit_buttons.height() + button_bar_height + 9}px") # +9 is not good
+        @_dragbar.css(top: "#{top_offset}px")
 
         # position the preview
         @preview.offset
@@ -642,7 +662,7 @@ class exports.HTML_MD_Editor extends editor.FileEditor
         @preview.css
             left  : editor_width + left + 7
             width : width - (editor_width + left + 7)
-            top   : "#{@edit_buttons.height() + button_bar_height + 15}px"
+            top   : "#{top_offset}px"
 
         @preview.scrollTop(@preview_scroll_position)
 

--- a/src/smc-webapp/editor.html
+++ b/src/smc-webapp/editor.html
@@ -378,20 +378,6 @@ Editor for files in a project
 
     <!-- Templates for the embedded PDF previewer: just uses the built-in renderer; can't cope with file updates, inverse search, etc. -->
     <div class="salvus-editor-pdf-preview-embed">
-        <div class="salvus-editor-codemirror-button-row">
-            <span class="salvus-editor-pdf-preview-embed-spinner hide"></span>
-            <span class="btn-group">
-                <a class="btn btn-default btn-lg visible-xs" href="#close" ><i class="fa fa-toggle-up"></i> <span class="hidden-xs">Files...</span></a>
-                <a class="btn btn-default btn-lg visible-xs" href="#refresh"><i class="fa fa-refresh"></i> <span class="hidden-xs"> Refresh</span></a>
-                <a class="btn btn-default hidden-xs" href="#refresh"><i class="fa fa-refresh"></i> <span class="hidden-xs"> Refresh</span></a>
-            </span>
-            <span class="btn-group pull-right">
-            <a class="btn btn-default salvus-editor-pdf-title hidden-xs">
-                <i class="fa fa-external-link"></i>
-                <span></span>
-            </a>
-            </span>
-        </div>
         <div class="salvus-editor-pdf-preview-embed-page">
             <iframe frameborder="0" scrolling="no">
                 <br>

--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -422,12 +422,12 @@ class exports.LatexEditor extends editor.FileEditor
             width = chat_pos.left
 
         {top, left} = @element.offset()
-        editor_width = (width - left)*@_split_pos
+        editor_width = (width - left) * @_split_pos
 
-        @_dragbar.css('left',editor_width+left)
+        @_dragbar.css('left', editor_width + left)
         @latex_editor.show(width:editor_width)
 
-        button_bar_height = @element.find(".salvus-editor-codemirror-button-container").height()
+        button_bar_height = @element.find(".salvus-editor-codemirror-button-row").height()
 
         @_right_pane_position =
             start : editor_width + left + 7
@@ -440,7 +440,8 @@ class exports.LatexEditor extends editor.FileEditor
         else
             @show_page()
 
-        @_dragbar.height(@latex_editor.element.height()).css('top', button_bar_height+2)
+        @_dragbar.height(@latex_editor.element.height())
+        @_dragbar.css('top', button_bar_height + 2)
 
     focus: () =>
         @latex_editor?.focus()
@@ -500,6 +501,7 @@ class exports.LatexEditor extends editor.FileEditor
             cb      : undefined
         button = @element.find("a[href=\"#log\"]")
         button.icon_spin(true)
+        @_show() # update layout, since showing spinner might cause a linebreak in the button bar
         log_output = @log.find("textarea")
         log_output.text("")
         if not opts.command?
@@ -524,6 +526,7 @@ class exports.LatexEditor extends editor.FileEditor
             latex_command : opts.command
             cb            : (err, log) =>
                 button.icon_spin(false)
+                @_show() # update layout, since hiding spinner might cause a linebreak in the button bar to go away
                 opts.cb?()
 
     render_error_page: () =>


### PR DESCRIPTION
issue #501

The core problem with #501 is, that some layout calculations are done too early, done when not needed (editor not shown), or not at all (when latex compiles, the spinner in the build button might cause a linebreak).  It also deals with issues like adding some negative top margins in the css, while adding positive top space via element styling. Despite that, it removes a non-existing button bar from the embedded pdf preview, makes the divider line more visible, and uses underscore's debounce instead some custom throttling.

I've tested it in chrome and firefox, with 100% and 150% zoom, also narrowing the window to trigger the responsive view for mobile. For me it looks all good, so I hope it's fine everywhere.