### PR TITLE
sync: dealing with file paths not inside the project

### DIFF
--- a/src/smc-util/syncstring.coffee
+++ b/src/smc-util/syncstring.coffee
@@ -501,8 +501,10 @@ class SyncDoc extends EventEmitter
             doc               : required   # String-based document that we're editing.  This must have methods:
                 # get -- returns a string: the live version of the document
                 # set -- takes a string as input: sets the live version of the document to this.
+
         if not opts.string_id?
             opts.string_id = schema.client_db.sha1(opts.project_id, opts.path)
+
         @_closed         = true
         @_string_id     = opts.string_id
         @_project_id    = opts.project_id

--- a/src/smc-webapp/project_file.cjsx
+++ b/src/smc-webapp/project_file.cjsx
@@ -86,10 +86,7 @@ exports.initialize = (path, redux, project_id, is_public) ->
 exports.generate = (path, redux, project_id, is_public) ->
     is_public = !!is_public
     ext = filename_extension(path).toLowerCase()
-    e = file_editors[is_public][ext]
-    if not e?
-        # fallback
-        e = file_editors[is_public]['']
+    e = file_editors[is_public][ext] ? file_editors[is_public]['']
     generator = e.generator
     if generator?
         return generator(path, redux, project_id)

--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -304,6 +304,11 @@ class SynchronizedDocument2 extends SynchronizedDocument
         @editor.show_startup_message("Loading...", 'info')
         @codemirror.setOption('readOnly', true)
         @codemirror1.setOption('readOnly', true)
+
+        if @filename[0] == '/'
+            # uses symlink to '/', which is created by start_smc
+            @filename = '.smc/root' + @filename
+
         id = require('smc-util/schema').client_db.sha1(@project_id, @filename)
         @_syncstring = salvus_client.sync_string
             id         : id


### PR DESCRIPTION
issue #591

this patch indirectly prefixes the filename for SyncDoc (and derived) objects with the symlink to the root directory in .smc

I think that's not the whole deal, since that sha1 sum comes up at more places, but at least `open /tmp/text.md` works.