### PR TITLE
webapp: only expose smc.client and related objects for testing

### DIFF
--- a/src/smc-webapp/billing.cjsx
+++ b/src/smc-webapp/billing.cjsx
@@ -149,11 +149,11 @@ class BillingActions extends Actions
                 async.parallel([
                     (cb) =>
                         # delete payment methods
-                        ids = (x.id for x in smc.redux.getStore('billing').getIn(['customer', 'sources', 'data'])?.toJS() ? [])
+                        ids = (x.id for x in redux.getStore('billing').getIn(['customer', 'sources', 'data'])?.toJS() ? [])
                         async.map(ids, @delete_payment_method, cb)
                     (cb) =>
                         # cancel subscriptions
-                        ids = (x.id for x in smc.redux.getStore('billing').getIn(['customer', 'subscriptions', 'data'])?.toJS() ? []   when not x.canceled_at)
+                        ids = (x.id for x in redux.getStore('billing').getIn(['customer', 'subscriptions', 'data'])?.toJS() ? []   when not x.canceled_at)
                         async.map(ids, @cancel_subscription, cb)
                 ], cb)
         ], cb)

--- a/src/smc-webapp/browser.coffee
+++ b/src/smc-webapp/browser.coffee
@@ -1,3 +1,24 @@
+##############################################################################
+#
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2015 -- 2016, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
 {redux} = require('./smc-react')
 
 # Calling set_window_title will set the title, but also put a notification

--- a/src/smc-webapp/client_browser.coffee
+++ b/src/smc-webapp/client_browser.coffee
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2014, William Stein
+#    Copyright (C) 2014 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -80,15 +80,22 @@ class Connection extends client.Connection
         # you have to change the context to *top*!   See
         # http://stackoverflow.com/questions/3275816/debugging-iframes-with-chrome-developer-tools/8581276#8581276
         #
+        setTimeout(@_init_idle, 15 * 1000)
+        super(opts)
+        @_setup_window_smc()
+
+    _setup_window_smc: () =>
+        # if we are in DEBUG mode, inject the client into the global window object
+        if not (DEBUG ? false)
+            return
         window.smc = {}
         window.smc.client = @
         window.smc.misc = require('smc-util/misc')
-        window.smc.done = window.smc.misc.done  # useful for debugging
-        window.smc.sha1 = require('sha1')       # used only for debugging
-        window.smc.schema = require('smc-util/schema')  # only for debugging
-        window.smc.synctable_debug = require('smc-util/synctable').set_debug  # use to enable/disable verbose synctable logging
-        setTimeout(@_init_idle, 15 * 1000)
-        super(opts)
+        window.smc.done = window.smc.misc.done
+        window.smc.sha1 = require('sha1')
+        window.smc.schema = require('smc-util/schema')
+        # use to enable/disable verbose synctable logging
+        window.smc.synctable_debug = require('smc-util/synctable').set_debug
 
     _init_idle: () =>
         ###
@@ -96,7 +103,7 @@ class Connection extends client.Connection
         It is pushed forward each time @_idle_reset is called.
         The setInterval timer checks every minute, if the current time is past this @_init_time.
         If so, the user is 'idle'.
-        To keep 'active', call smc.client.idle_reset as often as you like:
+        To keep 'active', call salvus_client.idle_reset as often as you like:
         A document.body event listener here and one for each jupyter iframe.body (see jupyter.coffee).
         ###
 
@@ -106,11 +113,11 @@ class Connection extends client.Connection
         setInterval(@_idle_check, 60 * 1000)
 
         # call this idle_reset like a function
-        # will reset timer on *first* call and then every 10secs while being called
-        @idle_reset = _.throttle(smc.client._idle_reset, 15 * 1000)
+        # will reset timer on *first* call and then every 15secs while being called
+        @idle_reset = _.throttle(@_idle_reset, 15 * 1000)
 
         # activate a listener on our global body (universal sink for bubbling events, unless stopped!)
-        $(document).on("click mousemove keydown focusin", "body", smc.client.idle_reset)
+        $(document).on("click mousemove keydown focusin", "body", @idle_reset)
 
         delayed_disconnect = undefined
 
@@ -264,4 +271,3 @@ exports.connect = (url) ->
         return connection = new Connection(url)
 
 exports.connect()
-

--- a/src/smc-webapp/client_browser.coffee
+++ b/src/smc-webapp/client_browser.coffee
@@ -86,7 +86,7 @@ class Connection extends client.Connection
 
     _setup_window_smc: () =>
         # if we are in DEBUG mode, inject the client into the global window object
-        if not (DEBUG ? false)
+        if not DEBUG
             return
         window.smc = {}
         window.smc.client = @

--- a/src/smc-webapp/console.coffee
+++ b/src/smc-webapp/console.coffee
@@ -142,7 +142,7 @@ class Console extends EventEmitter
         if @opts.project_id
             @project_id = @opts.project_id
 
-        @_project_actions = smc.redux.getProjectActions(@project_id)
+        @_project_actions = redux.getProjectActions(@project_id)
 
         if @opts.renderer == 'auto'
             if IS_MOBILE
@@ -303,7 +303,8 @@ class Console extends EventEmitter
             # In case nothing comes back soon, we reconnect -- maybe the session is dead?
             # We wait 10x the ping time, so if connection is slow, this won't
             # constantly reconnect, but it is very fast in case the connection is fast.
-            latency = smc.client.latency()
+            {salvus_client} = require('./salvus_client')
+            latency = salvus_client.latency()
             if latency?
                 delay = Math.min(4000, latency*10)
                 setTimeout(@reconnect_if_no_recent_data, delay)

--- a/src/smc-webapp/d3.coffee
+++ b/src/smc-webapp/d3.coffee
@@ -6,7 +6,7 @@ misc = require('smc-util/misc')
 d3 = require('d3/d3')
 
 # Make d3 available to users in general.
-window?.smc?.d3 = d3
+window?.d3 = d3
 
 $.fn.extend
     d3: (opts={}) ->

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -658,7 +658,8 @@ class FileEditor extends EventEmitter
         # if above line reveals it, give it a bit time to do the layout first
         @_show(opts)  # critical -- also do an intial layout!  Otherwise get a horrible messed up animation effect.
         setTimeout((=> @_show(opts)), 10)
-        window?.smc?.doc = @  # useful for debugging...
+        if DEBUG ? false
+            window?.smc?.doc = @  # useful for debugging...
 
     _show: (opts={}) =>
         # define in derived class
@@ -2318,7 +2319,7 @@ class PDFLatexDocument
         )
 
 # FOR debugging only
-if require('feature').DEBUG
+if DEBUG ? false
     exports.PDFLatexDocument = PDFLatexDocument
 
 class PDF_Preview extends FileEditor

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -658,7 +658,7 @@ class FileEditor extends EventEmitter
         # if above line reveals it, give it a bit time to do the layout first
         @_show(opts)  # critical -- also do an intial layout!  Otherwise get a horrible messed up animation effect.
         setTimeout((=> @_show(opts)), 10)
-        if DEBUG ? false
+        if DEBUG
             window?.smc?.doc = @  # useful for debugging...
 
     _show: (opts={}) =>
@@ -2319,7 +2319,7 @@ class PDFLatexDocument
         )
 
 # FOR debugging only
-if DEBUG ? false
+if DEBUG
     exports.PDFLatexDocument = PDFLatexDocument
 
 class PDF_Preview extends FileEditor

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -708,7 +708,6 @@ exports.FileEditor = FileEditor
 ###############################################
 class CodeMirrorEditor extends FileEditor
     constructor: (@project_id, @filename, content, opts) ->
-        window.w = @
         editor_settings = redux.getStore('account').get_editor_settings()
         opts = @opts = defaults opts,
             mode                      : undefined

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -2948,6 +2948,7 @@ class PublicCodeMirrorEditor extends CodeMirrorEditor
 
 class PublicSagews extends PublicCodeMirrorEditor
     constructor: (@project_id, @filename, content, opts) ->
+        opts.allow_javascript_eval = false
         super @project_id, @filename, content, opts, (err) =>
             @element.find("a[href=\"#split-view\"]").hide()  # disable split view
             if not err

--- a/src/smc-webapp/editor_codemirror.cjsx
+++ b/src/smc-webapp/editor_codemirror.cjsx
@@ -1,8 +1,8 @@
-###############################################################################
+##############################################################################
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2015, William Stein
+#    Copyright (C) 2015 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by

--- a/src/smc-webapp/editor_codemirror.cjsx
+++ b/src/smc-webapp/editor_codemirror.cjsx
@@ -73,7 +73,6 @@ default_store_state =
 
 init_redux = (path, redux, project_id) ->
     name = redux_name(project_id, path)
-    console.log("store=smc.redux.getStore('#{name}');actions=smc.redux.getActions('#{name}');")
     if redux.getActions(name)?
         return  # already initialized
     actions = redux.createActions(name, CodemirrorActions)

--- a/src/smc-webapp/editor_git.cjsx
+++ b/src/smc-webapp/editor_git.cjsx
@@ -300,7 +300,6 @@ class GitActions extends Actions
 
     add_or_removed_checked_files : (name, listing_type) =>
         store = @redux.getStore(@name)
-        window.actions = @; window.store = store
         if not store.get('checked_files')
             @setState(checked_files: {"tracked": [], "untracked": []})
         # I was unable to modify the object as is Only worked once I did -> JSON -> object

--- a/src/smc-webapp/editor_history.coffee
+++ b/src/smc-webapp/editor_history.coffee
@@ -39,7 +39,8 @@ underscore = require('underscore')
 
 class exports.HistoryEditor extends FileEditor
     constructor: (@project_id, @filename, content, opts) ->
-        window.h = @  # DEBUGGING
+        if DEBUG
+            window.h = @
         @init_paths()
         @init_view_doc opts, (err) =>
             if not err

--- a/src/smc-webapp/editor_history.coffee
+++ b/src/smc-webapp/editor_history.coffee
@@ -39,8 +39,6 @@ underscore = require('underscore')
 
 class exports.HistoryEditor extends FileEditor
     constructor: (@project_id, @filename, content, opts) ->
-        if DEBUG
-            window.h = @
         @init_paths()
         @init_view_doc opts, (err) =>
             if not err

--- a/src/smc-webapp/editor_history.coffee
+++ b/src/smc-webapp/editor_history.coffee
@@ -1,13 +1,32 @@
-###
-Viewer for history of changes to a document
-###
+##############################################################################
+#
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2015 -- 2016, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+# Viewer for history of changes to a document
+###############################################################################
 
 $ = window.$
 
 misc = require('smc-util/misc')
 
 {salvus_client} = require('./salvus_client')
-
+{redux} = require('./smc-react')
 {FileEditor, codemirror_session_editor} = require('./editor')
 
 sagews  = require('./sagews')
@@ -149,7 +168,7 @@ class exports.HistoryEditor extends FileEditor
             return false
 
         open_file = () =>
-            smc.redux.getProjectActions(@project_id).open_file
+            redux.getProjectActions(@project_id).open_file
                 path       : @_open_file_path
                 foreground : true
 
@@ -295,9 +314,9 @@ class exports.HistoryEditor extends FileEditor
         usernames = []
         for account_id,_ of account_ids
             if account_id == @project_id
-                name = "Project: " + smc.redux.getStore('projects')?.get_title(account_id)
+                name = "Project: " + redux.getStore('projects')?.get_title(account_id)
             else
-                name = smc.redux.getStore('users')?.get_name(account_id)
+                name = redux.getStore('users')?.get_name(account_id)
             if name?
                 usernames.push(misc.trunc_middle(name,25).trim())
         if usernames.length > 0
@@ -333,9 +352,9 @@ class exports.HistoryEditor extends FileEditor
         account_id = @syncstring.account_id(time)
         time_sent  = @syncstring.time_sent(time)
         if account_id == @project_id
-            name = "Project: " + smc.redux.getStore('projects')?.get_title(account_id)
+            name = "Project: " + redux.getStore('projects')?.get_title(account_id)
         else
-            name = smc.redux.getStore('users')?.get_name(account_id)
+            name = redux.getStore('users')?.get_name(account_id)
         if name?
             username = misc.trunc_middle(name, 50)
 
@@ -452,7 +471,7 @@ class exports.HistoryEditor extends FileEditor
     show: () =>
         if not @is_active() or not @element? or not @view_doc?
             return
-        top = smc.redux.getProjectStore(@project_id).get('editor_top_position')
+        top = redux.getProjectStore(@project_id).get('editor_top_position')
         @element.css('top', top)
         if top == 0
             @element.css('position':'fixed', 'width':'100%')

--- a/src/smc-webapp/editor_jupyter.coffee
+++ b/src/smc-webapp/editor_jupyter.coffee
@@ -1,28 +1,43 @@
-###
-SageMathCloud: A collaborative web-based interface to Sage, Python, LaTeX and the Terminal.
-
-    Copyright (C) 2014, 2015, 2016, William Stein
-
-Jupyter Notebook Synchronization
-
-There are multiple representations of the notebook.
-
-   - @doc      = syncstring version of the notebook (uses SMC sync functionality)
-   - @nb       = the visible view stored in the browser DOM
-   - @filename = the .ipynb file on disk
-
-In addition, every other browser opened viewing the notebook has it's own @doc and @nb, and
-there is a single upstream copy of @doc in the local_hub daemon.
-
-The user edits @nb.  Periodically we check to see if any changes were made (@nb.dirty) and
-if so, we copy the state of @nb to @doc's live.
-
-When @doc changes do to some other user changing something, we compute a diff that tranforms
-the live notebook from its current state to the state that matches the new version of @doc.
-See the function set_nb below.  Incidentally, I came up with this approach from scratch after
-trying a lot of ideas, though in hindsite it's exactly the same as what React.js does (though
-I didn't know about React.js at the time).
-###
+##############################################################################
+#
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2014 -- 2016, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+# Jupyter Notebook Synchronization
+#
+# There are multiple representations of the notebook.
+#
+#    - @doc      = syncstring version of the notebook (uses SMC sync functionality)
+#    - @nb       = the visible view stored in the browser DOM
+#    - @filename = the .ipynb file on disk
+#
+# In addition, every other browser opened viewing the notebook has it's own @doc and @nb, and
+# there is a single upstream copy of @doc in the local_hub daemon.
+#
+# The user edits @nb.  Periodically we check to see if any changes were made (@nb.dirty) and
+# if so, we copy the state of @nb to @doc's live.
+#
+# When @doc changes do to some other user changing something, we compute a diff that tranforms
+# the live notebook from its current state to the state that matches the new version of @doc.
+# See the function set_nb below.  Incidentally, I came up with this approach from scratch after
+# trying a lot of ideas, though in hindsite it's exactly the same as what React.js does (though
+# I didn't know about React.js at the time).
+###############################################################################
 
 # How long to try to download Jupyter notebook before giving up with an error.  Load times in excess of
 # a minute can happen; this may be the SMC proxy being slow - not sure yet... but at least
@@ -236,9 +251,9 @@ class JupyterWrapper extends EventEmitter
         # all always seems to cause a dialog to pop up, even if the user doesn't want one according to smc's
         # own prefs.
         @frame.window.onbeforeunload = null
-        # when active, periodically reset the idle timeout time in client_browser
+        # when active, periodically reset the idle timer's reset time in client_browser.Connection
         # console.log 'iframe', @iframe
-        @iframe.contents().find("body").on("click mousemove keydown focusin", smc.client.idle_reset)
+        @iframe.contents().find("body").on("click mousemove keydown focusin", salvus_client.idle_reset)
 
     install_custom_undo_redo: (undo, redo) =>
         @frame.CodeMirror.prototype.undo = undo
@@ -513,7 +528,7 @@ class JupyterWrapper extends EventEmitter
         # ensure @_cursors is defined; this is map from key to ...?
         #console.log("draw_other_cursors(#{account_id}, #{misc.to_json(locs)})")
         @_cursors ?= {}
-        @_users   ?= smc.redux.getStore('users')  # SMELL -- obviously not like this...
+        @_users   ?= redux.getStore('users')  # TODO -- obviously not like this...
         x = @_cursors[account_id]
         if not x?
             x = @_cursors[account_id] = []
@@ -1314,7 +1329,7 @@ class JupyterNBViewer
             # callback, run after "load" event below this line
             @iframe.load ->
                 # could become undefined due to other things happening...
-                @iframe?.contents().find("body").on("click mousemove keydown focusin", smc.client.idle_reset)
+                @iframe?.contents().find("body").on("click mousemove keydown focusin", salvus_client.idle_reset)
             @iframe.attr('src', @ipynb_html_src)
 
         @element.css(top: redux.getProjectStore(@project_id).get('editor_top_position'))

--- a/src/smc-webapp/feature.coffee
+++ b/src/smc-webapp/feature.coffee
@@ -84,7 +84,8 @@ exports.get_mobile = () ->
 exports.is_responsive_mode = () ->
     return $(".salvus-responsive-mode-test").width() < 768
 
-# usually injected by webpack based on '--debug' cmd line parameter, except for static renderings
-exports.DEBUG = DEBUG ? false
-if exports.DEBUG
-    console.log "DEBUG MODE:", exports.DEBUG
+# DEBUG is injected by webpack and its value is true if the '--debug' cmd line parameter is set.
+# For react-static renderings, it isn't set and hence a reference error.
+# Therefore safeguard it with `? false` whereever you use it.
+if DEBUG ? false
+    console.log "DEBUG MODE:", DEBUG

--- a/src/smc-webapp/feature.coffee
+++ b/src/smc-webapp/feature.coffee
@@ -85,7 +85,6 @@ exports.is_responsive_mode = () ->
     return $(".salvus-responsive-mode-test").width() < 768
 
 # DEBUG is injected by webpack and its value is true if the '--debug' cmd line parameter is set.
-# For react-static renderings, it isn't set and hence a reference error.
-# Therefore safeguard it with `? false` whereever you use it.
-if DEBUG ? false
+# You can use DEBUG anywhere in the webapp code!
+if DEBUG
     console.log "DEBUG MODE:", DEBUG

--- a/src/smc-webapp/last.coffee
+++ b/src/smc-webapp/last.coffee
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2014, William Stein
+#    Copyright (C) 2014 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -20,11 +20,11 @@
 ###############################################################################
 
 
-###########################################################
+###############################################################################
 #
 # This should be the last code run on client application startup.
 #
-###########################################################
+###############################################################################
 
 $               = window.$
 {salvus_client} = require('./salvus_client')
@@ -45,9 +45,9 @@ else
     redux.getActions('page').set_active_tab('account')
 
 
-client = window.smc.client
+client = salvus_client
 if client._connected
-    # These events below currently (do to not having finished the react rewrite)
+    # These events below currently (due to not having finished the react rewrite)
     # have to be emited after the page loads, but may happen before.
     client.emit('connected')
     if client._signed_in

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -1604,12 +1604,12 @@ $("body").on "show.bs.tooltip", (e) ->
 
 exports.load_coffeescript_compiler = (cb) ->
     if CoffeeScript?
-        cb()
+        cb?()
     else
         require.ensure [], =>
             require("script!coffeescript/coffee-script.js")
             console.log("loaded CoffeeScript via reqire.ensure")
-            cb()
+            cb?()
             #$.getScript "/static/coffeescript/coffee-script.js", (script, status) ->
             #    console.log("loaded CoffeeScript -- #{status}")
             #    cb()

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -207,7 +207,7 @@ mathjax_enqueue = (x) ->
 exports.mathjax_finish_startup = ->
     for x in mathjax_queue
         mathjax_enqueue(x)
-    if DEBUG ? false
+    if DEBUG
         console.log 'finishing mathjax startup'
 
 mathjax_typeset = (el) ->

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -205,9 +205,10 @@ mathjax_enqueue = (x) ->
         mathjax_queue.push(x)
 
 exports.mathjax_finish_startup = ->
-    console.log 'finishing mathjax startup'
     for x in mathjax_queue
         mathjax_enqueue(x)
+    if DEBUG ? false
+        console.log 'finishing mathjax startup'
 
 mathjax_typeset = (el) ->
     # no MathJax.Hub, since there is no MathJax defined!

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1967,7 +1967,6 @@ exports.ProjectFiles = rclass ({name}) ->
     render : ->
         if not @props.checked_files?  # hasn't loaded/initialized at all
             return <Loading />
-        window.fprops = @props
 
         pay = @props.date_when_course_payment_required(@props.project_id)
         if pay? and pay <= salvus_client.server_time()

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -458,7 +458,6 @@ exports.ProjectLog = rclass ({name}) ->
             cursor = undefined
             selected = undefined
 
-        window.user_map = @props.user_map
         <Panel>
             <Row>
                 <Col sm=4>

--- a/src/smc-webapp/render.coffee
+++ b/src/smc-webapp/render.coffee
@@ -8,6 +8,8 @@ require('node-cjsx').transform()
 
 # there is a global window object, which is undefined in node.js' world -- we mock it and hope for the best.
 global['window'] = {}
+# webpack's injected DEBUG flag, we set it to false
+global['DEBUG']  = false
 
 # Code for static server-side rendering of the subscription options.
 # note, that we use renderToStaticMarkup, not renderToString

--- a/src/smc-webapp/sagews-eval.coffee
+++ b/src/smc-webapp/sagews-eval.coffee
@@ -1,0 +1,80 @@
+###
+Used for potentially dangerous
+code evaluation in Sage worksheets.
+###
+
+
+###
+Cell and Worksheet below are used when eval'ing %javascript blocks.
+###
+
+{defaults} = require('smc-util/misc')
+
+log = (s) -> console.log(s)
+
+class Cell
+    constructor : (opts) ->
+        @opts = defaults opts,
+            output  : undefined # jquery wrapped output area
+            cell_id : undefined
+        @output = opts.output
+        @cell_id = opts.cell_id
+
+class Worksheet
+    constructor : (worksheet) ->
+        # Copy over exactly the methods we need rather than everything.
+        # This is a token attempt ot make this slightly less dangerous.
+        # Obviously, execute_code is quite dangerous... for a particular project on the backend.
+        @worksheet = {}
+        for x in ['execute_code', 'interrupt', 'kill', 'element']
+            @worksheet[x] = worksheet[x]
+
+    execute_code: (opts) =>
+        if typeof opts == "string"
+            opts = {code:opts}
+        @worksheet.execute_code(opts)
+
+    interrupt: () =>
+        @worksheet.interrupt()
+
+    kill: () =>
+        @worksheet.kill()
+
+    set_interact_var : (opts) =>
+        elt = @worksheet.element.find("#" + opts.id)
+        if elt.length == 0
+            log("BUG: Attempt to set var of interact with id #{opts.id} failed since no such interact known.")
+        else
+            i = elt.data('interact')
+            if not i?
+                log("BUG: interact with id #{opts.id} doesn't have corresponding data object set.", elt)
+            else
+                i.set_interact_var(opts)
+
+    del_interact_var : (opts) =>
+        elt = @worksheet.element.find("#" + opts.id)
+        if elt.length == 0
+            log("BUG: Attempt to del var of interact with id #{opts.id} failed since no such interact known.")
+        else
+            i = elt.data('interact')
+            if not i?
+                log("BUG: interact with id #{opts.id} doesn't have corresponding data object del.", elt)
+            else
+                i.del_interact_var(opts.name)
+
+exports.sagews_eval = (code, worksheet, element, id, obj) ->
+    if element?
+        cell = new Cell(output : element, cell_id : id)
+    worksheet = new Worksheet(worksheet)
+    print     = (s...) ->
+        for i in [0...s.length]
+            if typeof(s[i]) != 'string'
+                s[i] = JSON.stringify(s[i] ? 'undefined')
+        cell.output.append($("<div></div>").text("#{s.join(' ')}"))
+    try
+        eval(code)
+    catch js_error
+        cell.output.append($("<div class='sagews-output-stderr'></div>").text("#{js_error}\n(see the Javascript console for more details)"))
+        console.warn("ERROR evaluating code '#{code}' in Sage worksheet", js_error)
+        console.trace()
+

--- a/src/smc-webapp/salvus_client.coffee
+++ b/src/smc-webapp/salvus_client.coffee
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2014, William Stein
+#    Copyright (C) 2014 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -30,4 +30,5 @@ if not window.smc_base_url?
 if window.location.hash.length > 1
     window.smc_target = decodeURIComponent(window.location.hash.slice(1))
 
-exports.salvus_client = window.smc.client
+client_browser = require('client_browser')
+exports.salvus_client = client_browser.connect()

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -515,6 +515,6 @@ exports.Table    = Table
 exports.Store    = Store
 exports.ReactDOM = require('react-dom')
 
-if DEBUG ? false
+if DEBUG
     smc?.redux = redux  # for convenience in the browser (mainly for debugging)
 

--- a/src/smc-webapp/smc-react.coffee
+++ b/src/smc-webapp/smc-react.coffee
@@ -1,19 +1,37 @@
-###
-Question: can we use redux to implement the same API as r.cjsx exports (which was built on Flummox).
-###
+##############################################################################
+#
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2015 -- 2016, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+# SMC specific wrapper around the redux library
+#
+# Question: can we use redux to implement the same API as r.cjsx exports (which was built on Flummox).
+###############################################################################
 
 {EventEmitter} = require('events')
+async          = require('async')
+immutable      = require('immutable')
+underscore     = require('underscore')
+React          = require('react')
+redux_lib      = require('redux')
 
-async = require('async')
-immutable = require('immutable')
-underscore = require('underscore')
-
-React = require('react')
-
-redux_lib = require('redux')
-{Provider, connect} = require('react-redux')
-
-misc = require('smc-util/misc')
+{Provider, connect}  = require('react-redux')
+misc                 = require('smc-util/misc')
 {defaults, required} = misc
 
 exports.COLOR =
@@ -497,5 +515,6 @@ exports.Table    = Table
 exports.Store    = Store
 exports.ReactDOM = require('react-dom')
 
-smc?.redux       = redux  # for convenience in the browser (mainly for debugging)
+if DEBUG ? false
+    smc?.redux = redux  # for convenience in the browser (mainly for debugging)
 

--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -286,7 +286,8 @@ class SynchronizedDocument2 extends SynchronizedDocument
             cursor_interval : 1000   # ignored below right now
             sync_interval   : 2000   # never send sync messages upstream more often than this
 
-        ## window.cm = @  ## DEBUGGING
+        if DEBUG
+            window.cm = @
 
         @project_id  = @editor.project_id
         @filename    = @editor.filename

--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -286,9 +286,6 @@ class SynchronizedDocument2 extends SynchronizedDocument
             cursor_interval : 1000   # ignored below right now
             sync_interval   : 2000   # never send sync messages upstream more often than this
 
-        if DEBUG
-            window.cm = @
-
         @project_id  = @editor.project_id
         @filename    = @editor.filename
         @connect     = @_connect

--- a/src/smc-webapp/syncdoc.coffee
+++ b/src/smc-webapp/syncdoc.coffee
@@ -2,7 +2,7 @@
 #
 # SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
 #
-#    Copyright (C) 2014, 2015, 2016 William Stein
+#    Copyright (C) 2014 -- 2016, SageMath, Inc.
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Gener@al Public License as published by
@@ -301,7 +301,7 @@ class SynchronizedDocument2 extends SynchronizedDocument
             cm.undo = @undo
             cm.redo = @redo
 
-        @_users = smc.redux.getStore('users')  # todo -- obviously not like this...
+        @_users = redux.getStore('users')  # TODO -- obviously not like this...
 
         @_other_cursor_timeout_s = 30  # only show active other cursors for this long
 

--- a/src/webpack.config.coffee
+++ b/src/webpack.config.coffee
@@ -116,10 +116,13 @@ GOOGLE_ANALYTICS = misc_node.GOOGLE_ANALYTICS
 
 # create a file base_url to set a base url
 BASE_URL      = misc_node.BASE_URL
+
+# output build environment variables of webpack
 console.log "SMC_VERSION      = #{SMC_VERSION}"
 console.log "SMC_GIT_REV      = #{GIT_REV}"
 console.log "NODE_ENV         = #{NODE_ENV}"
 console.log "BASE_URL         = #{BASE_URL}"
+console.log "DEBUG            = #{DEBUG}"
 console.log "INPUT            = #{INPUT}"
 console.log "OUTPUT           = #{OUTPUT}"
 console.log "GOOGLE_ANALYTICS = #{GOOGLE_ANALYTICS}"
@@ -128,10 +131,11 @@ console.log "GOOGLE_ANALYTICS = #{GOOGLE_ANALYTICS}"
 MATHJAX_URL    = misc_node.MATHJAX_URL  # from where the files are served
 MATHJAX_ROOT   = misc_node.MATHJAX_ROOT # where the symlink originates
 MATHJAX_LIB    = misc_node.MATHJAX_LIB  # where the symlink points to
-console.log "MATHJAX_URL  = #{MATHJAX_URL}"
-console.log "MATHJAX_ROOT = #{MATHJAX_ROOT}"
-console.log "MATHJAX_LIB  = #{MATHJAX_LIB}"
+console.log "MATHJAX_URL      = #{MATHJAX_URL}"
+console.log "MATHJAX_ROOT     = #{MATHJAX_ROOT}"
+console.log "MATHJAX_LIB      = #{MATHJAX_LIB}"
 
+# adds a banner to each compiled and minified source .js file
 banner = new webpack.BannerPlugin(
                         """\
                         This file is part of #{TITLE}.


### PR DESCRIPTION
This patch exposes `smc.*` objects iff webpack's injected `DEBUG` variable is true.

The range of areas it touches are the idle timeout, syncdoc, history editor, jupyter and billing.

Most importantly, transferring the "Connection" object from the client_browser to the salvus_client is done via a function call and not the global smc.client object.

Additionally, creating the statically rendered files also needs to be checked.