### PR TITLE
webapp: commit ac759ba062b5f erroneously removed the buttonbar from the embedded pdf viewer

### DIFF
--- a/src/smc-webapp/editor.html
+++ b/src/smc-webapp/editor.html
@@ -378,6 +378,20 @@ Editor for files in a project
 
     <!-- Templates for the embedded PDF previewer: just uses the built-in renderer; can't cope with file updates, inverse search, etc. -->
     <div class="salvus-editor-pdf-preview-embed">
+        <div class="salvus-editor-codemirror-button-row">
+            <span class="salvus-editor-pdf-preview-embed-spinner hide"></span>
+            <span class="btn-group">
+                <a class="btn btn-default btn-lg visible-xs" href="#close" ><i class="fa fa-toggle-up"></i> <span class="hidden-xs">Files...</span></a>
+                <a class="btn btn-default btn-lg visible-xs" href="#refresh"><i class="fa fa-refresh"></i> <span class="hidden-xs"> Refresh</span></a>
+                <a class="btn btn-default hidden-xs" href="#refresh"><i class="fa fa-refresh"></i> <span class="hidden-xs"> Refresh</span></a>
+            </span>
+            <span class="btn-group pull-right">
+            <a class="btn btn-default salvus-editor-pdf-title hidden-xs">
+                <i class="fa fa-external-link"></i>
+                <span></span>
+            </a>
+            </span>
+        </div>
         <div class="salvus-editor-pdf-preview-embed-page">
             <iframe frameborder="0" scrolling="no">
                 <br>

--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -66,9 +66,8 @@ class exports.LatexEditor extends editor.FileEditor
 
         # Embedded pdf page (not really a "preview" -- it's the real thing).
         @preview_embed = new editor.PDF_PreviewEmbed(@project_id, @filename.slice(0,n-3)+"pdf", undefined, {})
+        @preview_embed.element.find(".salvus-editor-codemirror-button-row").remove()
         @element.find(".salvus-editor-latex-pdf-preview").append(@preview_embed.element)
-        @preview_embed.element.find(".salvus-editor-pdf-title").hide()
-        @preview_embed.element.find("a[href=\"#refresh\"]").hide()
         @_pages['pdf-preview'] = @preview_embed
 
         # Initalize the log


### PR DESCRIPTION
this fixes this by reverting this and instead removes the buttonbar via jquery from the latex editor pdf previewer