### PR TITLE
docstrings for %octave and %r using jupyter

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2064,6 +2064,23 @@ sh.jupyter_kernel = None
 
 # use jupyter kernel for GNU octave instead of sage interpreter interface
 def octave(code=None,**kwargs):
+    r"""
+    Run GNU Octave code in a sage worksheet.
+
+    INPUT:
+
+    - ``code`` -- a string containing code
+
+    Use as a decorator. For example, put this in a cell and evaluate it::
+
+        %octave
+        x = -10:0.1:10;
+        plot (x, sin (x))
+
+    .. note::
+
+        SMC %octave mode uses the jupyter `octave` kernel.
+    """
     if octave.jupyter_kernel is None:
         octave.jupyter_kernel = jupyter("octave")
     return octave.jupyter_kernel(code,**kwargs)
@@ -2071,6 +2088,23 @@ octave.jupyter_kernel = None
 
 # jupyter kernel for %ir mode
 def r(code=None,**kwargs):
+    r"""
+    Run R code in a sage worksheet.
+
+    INPUT:
+
+    - ``code`` -- a string containing code
+
+    Use as a decorator. For example, put this in a cell and evaluate it to see a scatter plot
+    of built-in mtcars dataframe variables `mpg` vs `wt`::
+
+        %r
+        with(mtcars,plot(wt,mpg))
+
+    .. note::
+
+        SMC %r mode uses the jupyter `ir` kernel.
+    """
     if r.jupyter_kernel is None:
         r.jupyter_kernel = jupyter("ir")
     return r.jupyter_kernel(code,**kwargs)


### PR DESCRIPTION
Add docstrings for the new jupyter versions of these modes. There was a [posting on sage-devel](https://groups.google.com/d/msg/sage-devel/QaBdHSNJuKg/yXwZ-MIiBAAJ) looking for doc on the new `r` in smc.