### PR TITLE
jupyter/sagews: using image scaling factor to resize it in sagews

### DIFF
--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -1316,6 +1316,16 @@ class SynchronizedWorksheet extends SynchronizedDocument2
         for x in a
             y           = $(x)
             src         = y.attr('src')
+            # see https://github.com/sagemathinc/smc/issues/1192
+            img_scaling = y.attr('smc-image-scaling')
+            if img_scaling?
+                y.get(0).onload = ->
+                    width     = this.naturalWidth
+                    factor    = parseFloat(img_scaling)
+                    if not isNaN(factor)
+                        new_width = width * factor
+                        $(this).css('width', "#{new_width}px")
+            # checking, if we need to fix the src path
             is_fullurl  = src.indexOf('://') != -1
             is_blob     = misc.startswith(src, "#{window.smc_base_url}/blobs/")
             # see https://github.com/sagemathinc/smc/issues/651

--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -1319,12 +1319,15 @@ class SynchronizedWorksheet extends SynchronizedDocument2
             # see https://github.com/sagemathinc/smc/issues/1192
             img_scaling = y.attr('smc-image-scaling')
             if img_scaling?
-                y.get(0).onload = ->
-                    width     = this.naturalWidth
-                    factor    = parseFloat(img_scaling)
+                img = y.get(0)
+                scale_img = ->
+                    width  = img.naturalWidth
+                    factor = parseFloat(img_scaling)
                     if not isNaN(factor)
                         new_width = width * factor
-                        $(this).css('width', "#{new_width}px")
+                        y.css('width', "#{new_width}px")
+                scale_img()
+                img.onload = scale_img
             # checking, if we need to fix the src path
             is_fullurl  = src.indexOf('://') != -1
             is_blob     = misc.startswith(src, "#{window.smc_base_url}/blobs/")

--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -223,13 +223,11 @@ def _jkmagic(kernel_name, **kwargs):
                     with open(fname,'w') as fo:
                         fo.write(data)
 
-                    #if run_code.smc_image_scaling is None:
-                    if run_code.sage_img_style is None:
+                    if run_code.smc_image_scaling is None:
                         salvus.file(fname)
                     else:
                         img_src = salvus.file(fname, show=False)
-                        htms = '<img src="{0}" style="{1}" />'.format(img_src, run_code.sage_img_style)
-                        #htms = '<img src="{0}" onload="this.width*={1}" />'.format(img_src, run_code.smc_image_scaling)
+                        htms = '<img src="{0}" smc-image-scaling="{1}" />'.format(img_src, run_code.smc_image_scaling)
                         salvus.html(htms)
                     os.unlink(fname)
 
@@ -351,8 +349,7 @@ def _jkmagic(kernel_name, **kwargs):
     # 'svg', 'png', 'jpeg'
     run_code.default_image_fmt = 'png'
 
-    #run_code.smc_image_scaling = None
-    run_code.sage_img_style = None
+    run_code.smc_image_scaling = None
 
     return run_code
 

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2108,8 +2108,7 @@ def r(code=None,**kwargs):
     if r.jupyter_kernel is None:
         r.jupyter_kernel = jupyter("ir")
         r.jupyter_kernel('options(repr.plot.res = 240)')
-        #r.jupyter_kernel.smc_image_scaling = .5
-        r.jupyter_kernel.sage_img_style = "width: 50%; height: 50%;"
+        r.jupyter_kernel.smc_image_scaling = .5
     return r.jupyter_kernel(code,**kwargs)
 r.jupyter_kernel = None
 


### PR DESCRIPTION
issue #1192

This is actually really weird. When the output renders, the image is drawn (at least) two times. The first time around it is all fine, the naturalWidth is like it should be, scaling works. It should just stop there!

But immediately afterwards, probably triggered by some sync mechanism, the output is rendered again, the naturalWidth is unfortunately 0 (I assume, the image is removed from the DOM but not loaded) and the calculated width is zero. Therefore, here in this code, there is this addition to do the calculation after it has been loaded the second time around.