### PR TITLE
webapp/sagews: display output spans as blocks, span-wrap images and improve multiline-selections of text output

### DIFF
--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -329,10 +329,11 @@
 //
 // this messes up codemirror themes
 
-
 .sagews-output
-  white-space : normal
-  word-wrap   : break-word
+  display        : block
+  white-space    : normal
+  word-wrap      : break-word
+  padding-left   : 2em
 
 .sagews-output-cm-gutter
   border-right : 1ex solid #5cb85c
@@ -340,9 +341,7 @@
 .sagews-output-cm-text
   overflow-x   : auto   !important  // for big image output and since mathjax doesn't wrap around properly yet (?)
   overflow-y   : hidden !important
-  max-width    : 100%    !important
-  margin-left  : 1em   !important
-  padding-left : 1em  !important
+  max-width    : 100%   !important
 
 .sagews-output-cm-wrap
   padding-top    : 1ex  !important
@@ -419,9 +418,10 @@
   /* so that tex is visible */
 
 .sagews-output-image
-  cursor     : pointer
   background : white
   /* so that, e.g., latex with transparent background is visible */
+  > img
+    cursor     : pointer
 
 .sagews-output-video
   cursor     : pointer

--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -1551,7 +1551,7 @@ class SynchronizedWorksheet extends SynchronizedDocument2
                                         elt.data('width', obj.opts.width / $(window).width())
 
                     when 'svg', 'png', 'gif', 'jpg', 'jpeg'
-                        img = $("<img src='#{target}' class='sagews-output-image'>")
+                        img = $("<span class='sagews-output-image'><img src='#{target}'></span>")
                         output.append(img)
 
                         if mesg.events?


### PR DESCRIPTION
this little change makes it easier to select multiline output. my test-case is to copy paste the whole output of `random_matrix(GF(2), 10, 10)`. works much better than it does right now.

I also checked it in firefox, and well, all other output types like images and md aren't touched by that. I also tested to switch to other codemirror themes...