### PR TITLE
smc_pyutil: using python2-nosite to avoid interferences with ~/.local

### DIFF
--- a/src/smc-build/smc-ansible/all-install.yaml
+++ b/src/smc-build/smc-ansible/all-install.yaml
@@ -36,8 +36,8 @@
           dest="{{ item[1] }}"
           owner=root group=root mode="u=rx,g=rx,o=rx"
     with_together:
-      - [ "files/python2-nosite",         "/usr/local/bin/python2-nosite"]
-      - [ "files/python3-nosite",         "/usr/local/bin/python3-nosite"]
+      - [ "files/python2-nosite",            "files/python3-nosite"]
+      - [ "/usr/local/bin/python2-nosite",   "/usr/local/bin/python3-nosite"]
 
   - name: "additional install packages for all machines"
     apt: name={{ item }} install_recommends=yes state=latest

--- a/src/smc_pyutil/setup.py
+++ b/src/smc_pyutil/setup.py
@@ -24,16 +24,19 @@ from distutils.core import Distribution
 d = Distribution()
 d.parse_command_line()
 
-# THIS IS NOT WORKING
+# CRITICAL!
+# Uses a wrapped python executable to not load the user's "site" packages in ~/.local.
+# Otherwise, setuptool's startup scripts do not work, if there is a conflicting
+# setuptools version in .local/lib/python-packages (or, any other locally installed python lib)
+# setting sys.executable changes the she-bang #!... at the top of these scripts
+# credits to http://stackoverflow.com/a/17329493
+python2_nosite = '/usr/local/bin/python2-nosite'
+# don't overwrite for local smc-in-smc development
 if 'user' not in d.command_options.get("install", {}).keys():
-    # CRITICAL!
-    # -s tells python to not load the user's "site" packages in ~/.local
-    # otherwise, setuptool's startup scripts do not work, if there is a conflicting
-    # setuptools version in .local/lib/python-packages (or, any other locally installed python lib)
-    # setting sys.executable changes the she-bang #!... at the top of these scripts
-    # credits to http://stackoverflow.com/a/17329493
-    import sys
-    sys.executable = '/usr/local/bin/python2-nosite'
+    # check, if python2_nosite exists and is executable
+    if os.path.isfile(python2_nosite) and os.access(python2_nosite, os.X_OK):
+        import sys
+        sys.executable = python2_nosite
 
 setup(
     name             = 'smc_pyutil',

--- a/src/smc_pyutil/setup.py
+++ b/src/smc_pyutil/setup.py
@@ -25,7 +25,7 @@ d = Distribution()
 d.parse_command_line()
 
 # THIS IS NOT WORKING
-if False and 'user' not in d.command_options.get("install", {}).keys():
+if 'user' not in d.command_options.get("install", {}).keys():
     # CRITICAL!
     # -s tells python to not load the user's "site" packages in ~/.local
     # otherwise, setuptool's startup scripts do not work, if there is a conflicting
@@ -33,7 +33,7 @@ if False and 'user' not in d.command_options.get("install", {}).keys():
     # setting sys.executable changes the she-bang #!... at the top of these scripts
     # credits to http://stackoverflow.com/a/17329493
     import sys
-    sys.executable = '/usr/bin/python -s'
+    sys.executable = '/usr/local/bin/python2-nosite'
 
 setup(
     name             = 'smc_pyutil',


### PR DESCRIPTION
this reverts 2f6bf61a9f5f and fixes #1213 

for reviewing: my test was to temporarily tell the setup.py to always change the executable (i.e. `if True: # ...`)  and then to see what it produces in my `~/.local` and that my local `smc-status` works.

`/usr/loca/bin/python2-nosite` is [this globally installed wrapper](https://github.com/sagemathinc/smc/blob/master/src/smc-build/smc-ansible/files/python2-nosite)