### PR TITLE
webapp/interact: parse_width spelling error -- #1212

### DIFF
--- a/src/smc-webapp/interact.coffee
+++ b/src/smc-webapp/interact.coffee
@@ -193,7 +193,7 @@ parse_width = (width) ->
         if typeof width == 'number'
             return "#{width}ex"
         else
-            return width1
+            return width
 
 interact_control = (desc, update) ->
     # Create and return a detached DOM element elt that represents


### PR DESCRIPTION
This also fixes

```
%prun
1+1
```

It's really strange, since that spelling error has been there since 2013? how is that possible?