### PR TITLE
hub/compute: public listing of directories with leading dashes -- #1221

### DIFF
--- a/src/smc-hub/compute-client.coffee
+++ b/src/smc-hub/compute-client.coffee
@@ -1934,7 +1934,13 @@ class ProjectClient extends EventEmitter
                         args.push("--hidden")
                     if opts.time
                         args.push("--time")
-                    for k in ['path', 'start', 'limit']
+                    # prefix relative paths with ./ such that names starting with a dash do not confuse parsing arguments
+                    args.push("--path")
+                    if opts.path[0] isnt '/'
+                        args.push("./#{opts.path}")
+                    else
+                        args.push(opts.path)
+                    for k in ['start', 'limit']
                         args.push("--#{k}"); args.push(opts[k])
                     dbg("get listing of files using options #{misc.to_safe_str(args)}")
                     @_action


### PR DESCRIPTION
how to test:

1. `mkdir -- -test`
2. share `-test` publicly
3. sign out
4. open the `-test` subdirectory in the public listing

one could philosophy about where in the layers to actually fix this. I opted for this place, since it makes no sense to deal with it in the front end code and I don't want to change the python parser (just by looking at the passed arguments, it is usually too late to disambiguate. the place where it is called needs to be fixed)