### PR TITLE
Allow copying file and folder names from the files listing

### DIFF
--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -1,6 +1,7 @@
 {Actions, Store, redux} = require('./smc-react')
 {salvus_client}         = require('./salvus_client')
 misc                    = require('smc-util/misc')
+immutable               = require('immutable')
 
 {set_url}               = require('./history')
 {set_window_title}      = require('./browser')
@@ -159,8 +160,18 @@ class PageActions extends Actions
     sign_in: =>
         false
 
+    log_keydown: (e) =>
+        key_is_down = @redux.getStore('page').get('key_is_down')
+        @setState(key_is_down: key_is_down.set(e.key, true))
 
-redux.createActions('page', PageActions)
+    log_keyup: (e) =>
+        key_is_down = @redux.getStore('page').get('key_is_down')
+        @setState(key_is_down: key_is_down.set(e.key, false))
+
+actions = redux.createActions('page', PageActions)
+
+$(window).on("keydown", actions.log_keydown)
+$(window).on("keyup", actions.log_keyup)
 
 # FUTURE: Save entire state to database for #450, saved workspaces
 class PageStore extends Store
@@ -169,6 +180,7 @@ class PageStore extends Store
 
 init_store =
     active_top_tab : 'account' # One of: projects, account, about, [project id]
+    key_is_down    : immutable.Map({})
 
 redux.createStore('page', PageStore, init_store)
 

--- a/src/smc-webapp/init_app.coffee
+++ b/src/smc-webapp/init_app.coffee
@@ -1,7 +1,6 @@
 {Actions, Store, redux} = require('./smc-react')
 {salvus_client}         = require('./salvus_client')
 misc                    = require('smc-util/misc')
-immutable               = require('immutable')
 
 {set_url}               = require('./history')
 {set_window_title}      = require('./browser')
@@ -160,18 +159,7 @@ class PageActions extends Actions
     sign_in: =>
         false
 
-    log_keydown: (e) =>
-        key_is_down = @redux.getStore('page').get('key_is_down')
-        @setState(key_is_down: key_is_down.set(e.key, true))
-
-    log_keyup: (e) =>
-        key_is_down = @redux.getStore('page').get('key_is_down')
-        @setState(key_is_down: key_is_down.set(e.key, false))
-
-actions = redux.createActions('page', PageActions)
-
-$(window).on("keydown", actions.log_keydown)
-$(window).on("keyup", actions.log_keyup)
+redux.createActions('page', PageActions)
 
 # FUTURE: Save entire state to database for #450, saved workspaces
 class PageStore extends Store
@@ -180,7 +168,6 @@ class PageStore extends Store
 
 init_store =
     active_top_tab : 'account' # One of: projects, account, about, [project id]
-    key_is_down    : immutable.Map({})
 
 redux.createStore('page', PageStore, init_store)
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -116,7 +116,7 @@ FileCheckbox = rclass
         @props.actions.set_most_recent_file_click(full_name)
 
     render: ->
-        <span onClick={@handle_click} onMouseDown={(e)=>e.stopPropagation()} onMouseUp={(e)=>e.stopPropagation()} style={@props.style}>
+        <span onClick={@handle_click} style={@props.style}>
             <Icon name={if @props.checked then 'check-square-o' else 'square-o'} fixedWidth style={fontSize:'14pt'}/>
         </span>
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -124,19 +124,19 @@ FileRow = rclass
     displayName : 'ProjectFiles-FileRow'
 
     propTypes :
-        name          : rtypes.string.isRequired
-        display_name  : rtypes.string  # if given, will display this, and will show true filename in popover
-        size          : rtypes.number.isRequired
-        time          : rtypes.number
-        checked       : rtypes.bool
-        bordered      : rtypes.bool
-        color         : rtypes.string
-        mask          : rtypes.bool
-        public_data   : rtypes.object
-        is_public     : rtypes.bool
-        current_path  : rtypes.string
-        actions       : rtypes.object.isRequired
-        shift_is_down : rtypes.bool
+        name         : rtypes.string.isRequired
+        display_name : rtypes.string  # if given, will display this, and will show true filename in popover
+        size         : rtypes.number.isRequired
+        time         : rtypes.number
+        checked      : rtypes.bool
+        bordered     : rtypes.bool
+        color        : rtypes.string
+        mask         : rtypes.bool
+        public_data  : rtypes.object
+        is_public    : rtypes.bool
+        current_path : rtypes.string
+        actions      : rtypes.object.isRequired
+        no_select    : rtypes.bool
 
     shouldComponentUpdate: (next) ->
         return @props.name != next.name          or
@@ -148,7 +148,7 @@ FileRow = rclass
         @props.public_data != next.public_data   or
         @props.current_path != next.current_path or
         @props.bordered != next.border           or
-        @props.shift_is_down != next.shift_is_down
+        @props.no_select != next.no_select
 
     render_icon: ->
         ext   = misc.filename_extension(@props.name)
@@ -250,7 +250,7 @@ FileRow = rclass
             style={row_styles}
             onMouseDown={@handle_mouse_down}
             onClick={@handle_click}
-            className={'noselect' if @props.shift_is_down}
+            className={'noselect' if @props.no_select}
         >
             <Col sm=2 xs=3>
                 <FileCheckbox
@@ -286,18 +286,18 @@ DirectoryRow = rclass
     displayName : 'ProjectFiles-DirectoryRow'
 
     propTypes :
-        name          : rtypes.string.isRequired
-        display_name  : rtypes.string  # if given, will display this, and will show true filename in popover
-        checked       : rtypes.bool
-        color         : rtypes.string
-        bordered      : rtypes.bool
-        time          : rtypes.number
-        mask          : rtypes.bool
-        public_data   : rtypes.object
-        is_public     : rtypes.bool
-        current_path  : rtypes.string
-        actions       : rtypes.object.isRequired
-        shift_is_down : rtypes.bool
+        name         : rtypes.string.isRequired
+        display_name : rtypes.string  # if given, will display this, and will show true filename in popover
+        checked      : rtypes.bool
+        color        : rtypes.string
+        bordered     : rtypes.bool
+        time         : rtypes.number
+        mask         : rtypes.bool
+        public_data  : rtypes.object
+        is_public    : rtypes.bool
+        current_path : rtypes.string
+        actions      : rtypes.object.isRequired
+        no_select    : rtypes.bool
 
     handle_mouse_down: (e) ->
         @setState
@@ -362,7 +362,7 @@ DirectoryRow = rclass
             overflowWrap   : 'break-word'
             verticalAlign  : 'sub'
 
-        <Row style={row_styles} onMouseDown={@handle_mouse_down} onClick={@handle_click} className={'noselect' if @props.shift_is_down}>
+        <Row style={row_styles} onMouseDown={@handle_mouse_down} onClick={@handle_click} className={'noselect' if @props.no_select}>
             <Col sm=2 xs=3>
                 <FileCheckbox
                     name         = {@props.name}
@@ -534,10 +534,6 @@ pager_range = (page_size, page_number) ->
 FileListing = rclass
     displayName: 'ProjectFiles-FileListing'
 
-    reduxProps:
-        page :
-            key_is_down : rtypes.immutable.Map
-
     propTypes:
         listing             : rtypes.array.isRequired
         file_map            : rtypes.object.isRequired
@@ -553,6 +549,7 @@ FileListing = rclass
         selected_file_index : rtypes.number
         project_id          : rtypes.string
         show_upload         : rtypes.bool
+        shift_is_down       : rtypes.bool
 
     getDefaultProps: ->
         file_search : ''
@@ -574,39 +571,38 @@ FileListing = rclass
         else
             color = 'white'
         apply_border = index == @props.selected_file_index and @props.file_search.length > 0 and @props.file_search[0] isnt TERM_MODE_CHAR
-        shift_is_down = @props.key_is_down.get("Shift")
         if isdir
             return <DirectoryRow
-                name          = {name}
-                display_name  = {display_name}
-                time          = {time}
-                key           = {index}
-                color         = {color}
-                bordered      = {apply_border}
-                mask          = {mask}
-                public_data   = {public_data}
-                is_public     = {is_public}
-                checked       = {checked}
-                current_path  = {@props.current_path}
-                actions       = {@props.actions}
-                shift_is_down = {shift_is_down}
+                name         = {name}
+                display_name = {display_name}
+                time         = {time}
+                key          = {index}
+                color        = {color}
+                bordered     = {apply_border}
+                mask         = {mask}
+                public_data  = {public_data}
+                is_public    = {is_public}
+                checked      = {checked}
+                current_path = {@props.current_path}
+                actions      = {@props.actions}
+                no_select    = {@props.shift_is_down}
             />
         else
             return <FileRow
-                name          = {name}
-                display_name  = {display_name}
-                time          = {time}
-                size          = {size}
-                color         = {color}
-                bordered      = {apply_border}
-                mask          = {mask}
-                public_data   = {public_data}
-                is_public     = {is_public}
-                checked       = {checked}
-                key           = {index}
-                current_path  = {@props.current_path}
-                actions       = {@props.actions}
-                shift_is_down = {shift_is_down}
+                name         = {name}
+                display_name = {display_name}
+                time         = {time}
+                size         = {size}
+                color        = {color}
+                bordered     = {apply_border}
+                mask         = {mask}
+                public_data  = {public_data}
+                is_public    = {is_public}
+                checked      = {checked}
+                key          = {index}
+                current_path = {@props.current_path}
+                actions      = {@props.actions}
+                no_select    = {@props.shift_is_down}
             />
 
     handle_parent: (e) ->
@@ -1837,6 +1833,25 @@ exports.ProjectFiles = rclass ({name}) ->
         actions : redux.getActions(name) # TODO: Do best practices way
         redux   : redux
 
+    getInitialState: ->
+        shift_is_down : false
+
+    componentDidMount: ->
+        $(window).on("keydown", @handle_files_key_down)
+        $(window).on("keyup", @handle_files_key_up)
+
+    componentWillUnmount: ->
+        $(window).off("keydown", @handle_files_key_down)
+        $(window).off("keyup", @handle_files_key_up)
+
+    handle_files_key_down: (e) ->
+        if e.key == "Shift"
+            @setState(shift_is_down : true)
+
+    handle_files_key_up: (e) ->
+        if e.key == "Shift"
+            @setState(shift_is_down : false)
+
     previous_page: ->
         if @props.page_number > 0
             @actions(name).setState(page_number : @props.page_number - 1)
@@ -2018,7 +2033,9 @@ exports.ProjectFiles = rclass ({name}) ->
                 create_folder       = {@create_folder}
                 selected_file_index = {@props.selected_file_index}
                 project_id          = {@props.project_id}
-                show_upload         = {@props.show_upload} />
+                show_upload         = {@props.show_upload}
+                shift_is_down       = {@state.shift_is_down}
+            />
         else
             <div style={fontSize:'40px', textAlign:'center', color:'#999999'} >
                 <Loading />

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -218,10 +218,10 @@ FileRow = rclass
 
     handle_mouse_down: (e) ->
         @setState
-            highlighted_text : window.getSelection().toString()
+            selection_at_last_mouse_down : window.getSelection().toString()
 
     handle_click: (e) ->
-        if window.getSelection().toString() == @state.highlighted_text
+        if window.getSelection().toString() == @state.selection_at_last_mouse_down
             @props.actions.open_file
                 path       : @fullpath()
                 foreground : misc.should_open_in_foreground(e)
@@ -301,10 +301,10 @@ DirectoryRow = rclass
 
     handle_mouse_down: (e) ->
         @setState
-            highlighted_text : window.getSelection().toString()
+            selection_at_last_mouse_down : window.getSelection().toString()
 
     handle_click: (e) ->
-        if window.getSelection().toString() == @state.highlighted_text
+        if window.getSelection().toString() == @state.selection_at_last_mouse_down
             path = misc.path_to_file(@props.current_path, @props.name)
             @props.actions.open_directory(path)
             @props.actions.set_file_search('')

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1062,6 +1062,14 @@ ProjectRow = rclass
                            user_map    = {@props.user_map} />
         return r_join(users)
 
+    handle_mouse_down: (e) ->
+        @setState
+            highlighted_text : window.getSelection().toString()
+
+    handle_click: (e) ->
+        if window.getSelection().toString() == @state.highlighted_text
+            @open_project_from_list(e)
+
     open_project_from_list: (e) ->
         @actions('projects').open_project
             project_id : @props.project.project_id
@@ -1082,7 +1090,7 @@ ProjectRow = rclass
             cursor          : 'pointer'
             wordWrap        : 'break-word'
 
-        <Well style={project_row_styles} onClick={@open_project_from_list}>
+        <Well style={project_row_styles} onClick={@handle_click} onMouseDown={@handle_mouse_down}>
             <Row>
                 <Col sm=3 style={fontWeight: 'bold', maxHeight: '7em', overflowY: 'auto'}>
                     <a>{html_to_text(@props.project.title)}</a>

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1064,10 +1064,10 @@ ProjectRow = rclass
 
     handle_mouse_down: (e) ->
         @setState
-            highlighted_text : window.getSelection().toString()
+            selection_at_last_mouse_down : window.getSelection().toString()
 
     handle_click: (e) ->
-        if window.getSelection().toString() == @state.highlighted_text
+        if window.getSelection().toString() == @state.selection_at_last_mouse_down
             @open_project_from_list(e)
 
     open_project_from_list: (e) ->


### PR DESCRIPTION
Fixes #1247 
- Allows highlighting text without opening the file
 - Applied to projects in the projects listing as well.
- Opens the file if you click on it
- Nothing is highlighted when you check multiple rows with `shift + click`