### PR TITLE
1251testdir

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_parsing.py
+++ b/src/smc_sagews/smc_sagews/sage_parsing.py
@@ -387,16 +387,29 @@ def introspect(code, namespace, preparse=True):
         if get_completions and target == expr:
             j      = len(expr)
             if '*' in expr:
-                #if '*' in expr and '* ' not in expr:
                 # this case includes *_factors<TAB> and abc =...;3 * ab[tab]
                 try:
                     pattern = expr.replace("*",".*").replace("?",".")
                     reg = re.compile(pattern+"$")
                     v = filter(reg.match, namespace.keys() + _builtin_completions)
+                    # for 2*sq[tab]
+                    if len(v) == 0:
+                        gle = guess_last_expression(expr)
+                        j = len(gle)
+                        if j > 0:
+                            target = gle
+                            v = [x[j:] for x in (namespace.keys() + _builtin_completions) if x.startswith(gle)]
                 except:
                     pass
             else:
                 v = [x[j:] for x in (namespace.keys() + _builtin_completions) if x.startswith(expr)]
+                # for 2+sqr[tab]
+                if len(v) == 0:
+                    gle = guess_last_expression(expr)
+                    j = len(gle)
+                    if j > 0 and j < len(expr):
+                        target = gle
+                        v = [x[j:] for x in (namespace.keys() + _builtin_completions) if x.startswith(gle)]
         else:
 
             # We will try to evaluate

--- a/src/smc_sagews/smc_sagews/tests/README.md
+++ b/src/smc_sagews/smc_sagews/tests/README.md
@@ -1,10 +1,14 @@
 # Pytest suite for sage_server
 
-## Purpose of These Tests
+## Goals
 
 - verify that sage worksheets return correct results for given cell inputs
 - back-end only test, uses message protocol to run tests against running sage_server
-- NOT to provide unit tests of functions internal to sagews modules
+
+## Non-goals
+
+- unit tests of functions internal to sagews modules
+- UI testing
 
 ## How to Use These Tests
 
@@ -20,6 +24,6 @@
 ### Running the Tests
 
 ```
-cd smc/src/smc_sagews/smc_sagews
-python -m pytest tests [-s]
+cd smc/src/smc_sagews/smc_sagews/tests
+python -m pytest
 ```

--- a/src/smc_sagews/smc_sagews/tests/README.md
+++ b/src/smc_sagews/smc_sagews/tests/README.md
@@ -27,3 +27,8 @@
 cd smc/src/smc_sagews/smc_sagews/tests
 python -m pytest
 ```
+
+## Test layout
+
+These tests follow the 'inline' test layout documented at pytest docs [Choosing a test layout / import rules](http://doc.pytest.org/en/latest/goodpractices.html#choosing-a-test-layout-import-rules).
+

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -599,3 +599,11 @@ def own_sage_server(request):
         print("killing all sage_server processes")
         os.system("pkill -f sage_server_command_line")
     request.addfinalizer(fin)
+
+@pytest.fixture(scope = "class")
+def test_ro_data_dir(request):
+    """
+    Return the directory containing the test file.
+    Used for tests which have read-only data files in the test dir.
+    """
+    return os.path.dirname(request.module.__file__)

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -7,8 +7,6 @@ import signal
 import struct
 import hashlib
 
-# import sys
-
 ###
 # much of the code here is copied from sage_server.py
 # cut and paste was done because it takes over 30 sec to import sage_server
@@ -375,12 +373,9 @@ def data_path(tmpdir_factory):
 @pytest.fixture()
 def exec2(request, sagews, test_id):
     r"""
-    Fixture for worksheet cell test. Depends on two other fixtures,
-    sagews and test_id.
-    - `` code `` -- string of code block to run
-
-    Fixture function exec2. If output & patterns are omitted, the cell is not
-    expected to produce a stdout result. Arguments after 'code' are optional.
+    Fixture function exec2. Depends on two other fixtures, sagews and test_id.
+    If output & patterns are omitted, the cell is not expected to produce a
+    stdout result. All arguments after 'code' are optional.
 
     - `` code `` -- string of code to run
 
@@ -559,7 +554,7 @@ def sagews(request):
     c_ack = conn._recv(1)
     assert c_ack == 'y',"expect ack for token, got %s"%c_ack
 
-    # start session
+    # open connection with sage_server and run tests
     msg = message.start_session()
     msg['type'] = 'sage'
     conn.send_json(msg)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -151,16 +151,19 @@ class TestAttach:
             print("attached files: %d"%len(attached_files()))
             print("\n".join(attached_files()))
         paf()"""),"attached files: 0\n\n")
-    def test_attach_sage_1(self, exec2):
-        exec2("%attach a.sage\npaf()", pattern="attached files: 1\n.*/a.sage\n")
+    def test_attach_sage_1(self, exec2, test_ro_data_dir):
+        fn = os.path.join(test_ro_data_dir, 'a.sage')
+        exec2("%attach {}\npaf()".format(fn), pattern="attached files: 1\n.*/a.sage\n")
     def test_attach_sage_2(self, exec2):
         exec2("f1('foo')","f1 arg = 'foo'\ntest f1 1\n")
-    def test_attach_py_1(self, exec2):
-        exec2("%attach a.py\npaf()", pattern="attached files: 2\n.*/a.py\n.*/a.sage\n")
+    def test_attach_py_1(self, exec2, test_ro_data_dir):
+        fn = os.path.join(test_ro_data_dir, 'a.py')
+        exec2("%attach {}\npaf()".format(fn), pattern="attached files: 2\n.*/a.py\n.*/a.sage\n")
     def test_attach_py_2(self, exec2):
         exec2("f2('foo')","test f2 1\n")
-    def test_attach_html_1(self, execblob):
-        execblob("%attach a.html", want_html=False, want_javascript=True, file_type='html')
+    def test_attach_html_1(self, execblob, test_ro_data_dir):
+        fn = os.path.join(test_ro_data_dir, 'a.html')
+        execblob("%attach {}".format(fn), want_html=False, want_javascript=True, file_type='html')
     def test_attach_html_2(self, exec2):
         exec2("paf()", pattern="attached files: 3\n.*/a.html\n.*/a.py\n.*/a.sage\n")
     def test_detach_1(self, exec2):

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -143,6 +143,10 @@ class TestIntrospect:
         """))
     def test_sage_autocomplete_1225b(self, execintrospect):
         execintrospect('z = 12 * y.', ["x"], '')
+    def test_sage_autocomplete_1252a(self, execintrospect):
+        execintrospect('2*sqr', ["t"], 'sqr')
+    def test_sage_autocomplete_1252b(self, execintrospect):
+        execintrospect('2+sqr', ["t"], 'sqr')
 
 class TestAttach:
     def test_define_paf(self, exec2):


### PR DESCRIPTION
Fix for #1251 so smc_sagews pytests can be run from any directory. Added fixture to set directory for read-only data files.

I updated the README.md to reflect where I usually run the tests. But tests now also work if you invoke them per the previous instructions, i.e.
```
cd smc/src/smc_sagews/smc_sagews
python -m pytest tests
```