### PR TITLE
1279scala ansi

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -125,6 +125,8 @@ def _jkmagic(kernel_name, **kwargs):
 
         INPUT:
 
+        -  ``s`` - string to display in output of sagews cell
+
         -  ``block`` - set false to prevent newlines between output segments
 
         -  ``scroll`` - set true to put output into scrolling div
@@ -133,6 +135,7 @@ def _jkmagic(kernel_name, **kwargs):
         """
         # `full = False` or else cell output is huge
         if "\x1b[" in s:
+            # use html output if ansi control code found in string
             h = conv.convert(s, full = False)
             if block:
                 h2 = '<pre style="font-family:monospace;">'+h+'</pre>'
@@ -269,8 +272,7 @@ def _jkmagic(kernel_name, **kwargs):
                             show(msg_data['text/latex'])
                         else:
                             txt = re.sub(r"^\[\d+\] ", "", msg_data[dispmode])
-                            sys.stdout.write(txt)
-                            sys.stdout.flush()
+                            hout(txt)
                     elif dispmode == 'text/html':
                         salvus.html(msg_data[dispmode])
                     elif dispmode == 'text/latex':

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2120,6 +2120,28 @@ def r(code=None,**kwargs):
     return r.jupyter_kernel(code,**kwargs)
 r.jupyter_kernel = None
 
+# jupyter kernel for %scala mode
+def scala211(code=None,**kwargs):
+    r"""
+    Run scala code in a sage worksheet.
+
+    INPUT:
+
+    - ``code`` -- a string containing code
+
+    Use as a decorator.
+
+    .. note::
+
+        SMC %scala211 mode uses the jupyter `scala211` kernel.
+    """
+    if scala211.jupyter_kernel is None:
+        scala211.jupyter_kernel = jupyter("scala211")
+    return scala211.jupyter_kernel(code,**kwargs)
+scala211.jupyter_kernel = None
+# add alias for generic scala
+scala = scala211
+
 def prun(code):
     """
     Use %prun followed by a block of code to profile execution of that

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -2120,61 +2120,6 @@ def r(code=None,**kwargs):
     return r.jupyter_kernel(code,**kwargs)
 r.jupyter_kernel = None
 
-## Monkey patch the R interpreter interface to support graphics, when
-## used as a decorator.
-
-#import sage.interfaces.r
-#def r_eval0(*args, **kwds):
-#    return sage.interfaces.r.R.eval(sage.interfaces.r.r, *args, **kwds).strip('\n')
-
-#_r_plot_options = ''
-#def set_r_plot_options(width=7, height=7):
-#    global _r_plot_options
-#    _r_plot_options = ", width=%s, height=%s"%(width, height)
-
-#r_dev_on = False
-#def r_eval(code, *args, **kwds):
-#    """
-#    Run a block of R code.
-
-#    EXAMPLES::
-
-#         sage: print r.eval("summary(c(1,2,3,111,2,3,2,3,2,5,4))")   # outputs a string
-#         Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
-#         1.00    2.00    3.00   12.55    3.50  111.00
-
-#    In the notebook, you can put %r at the top of a cell, or type "%default_mode r" into
-#    a cell to set the whole worksheet to r mode.
-
-#    NOTE: Any plots drawn using the plot command should "just work", without having
-#    to mess with special devices, etc.
-#    """
-#    # Only use special graphics support when using r as a cell decorator, since it has
-#    # a 10ms penalty (factor of 10 slowdown) -- which doesn't matter for interactive work, but matters
-#    # a lot if one had a loop with r.eval in it.
-#    if sage.interfaces.r.r not in salvus.code_decorators:
-#        return r_eval0(code, *args, **kwds)
-
-#    global r_dev_on
-#    if r_dev_on:
-#        return r_eval0(code, *args, **kwds)
-#    try:
-#        r_dev_on = True
-#        tmp = '/tmp/' + uuid() + '.svg'
-#        r_eval0("svg(filename='%s'%s)"%(tmp, _r_plot_options))
-#        s = r_eval0(code, *args, **kwds)
-#        r_eval0('dev.off()')
-#        return s
-#    finally:
-#        r_dev_on = False
-#        if os.path.exists(tmp):
-#            salvus.stdout('\n'); salvus.file(tmp, show=True); salvus.stdout('\n')
-#            os.unlink(tmp)
-
-#sage.interfaces.r.r.eval = r_eval
-#sage.interfaces.r.r.set_plot_options = set_r_plot_options
-
-
 def prun(code):
     """
     Use %prun followed by a block of code to profile execution of that

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -1778,8 +1778,8 @@ def serve(port, host, extra_imports=False):
                      'fortran', 'go', 'help', 'hide', 'hideall', 'input', 'javascript', 'julia',
                      'jupyter', 'license', 'load', 'md', 'mediawiki', 'modes', 'octave', 'pandoc',
                      'perl', 'plot3d_using_matplotlib', 'prun', 'python', 'python3', 'r', 'raw_input',
-                     'reset', 'restore', 'ruby', 'runfile', 'sage_chat', 'sage_eval', 'script',
-                     'search_doc', 'search_src', 'sh', 'show', 'show_identifiers', 'time',
+                     'reset', 'restore', 'ruby', 'runfile', 'sage_chat', 'sage_eval', 'scala', 'scala211',
+                     'script', 'search_doc', 'search_src', 'sh', 'show', 'show_identifiers', 'time',
                      'timeit', 'typeset_mode', 'var', 'wiki']:
             namespace[name] = getattr(sage_salvus, name)
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -6,6 +6,29 @@ import re
 import os
 from textwrap import dedent
 
+class TestScalaMode:
+    def test_scala_list(self, exec2):
+        exec2("%scala\nList(1,2,3)", html_pattern="res0.*List.*Int.*List.*1.*2.*3")
+
+class TestScala211Mode:
+    # example from ScalaTour-1.6, p. 31, Pattern Matching
+    # http://www.scala-lang.org/docu/files/ScalaTour-1.6.pdf
+    def test_scala211_pat1(self, exec2):
+        code = dedent('''
+        %scala
+        object MatchTest1 extends App {
+          def matchTest(x: Int): String = x match {
+            case 1 => "one"
+            case 2 => "two"
+            case _ => "many"
+          }
+          println(matchTest(3))
+        }
+        ''').strip()
+        exec2(code, html_pattern="defined.*object.*MatchTest1")
+    def test_scala211_pat2(self, exec2):
+        exec2("%scala211\nMatchTest1.main(Array())", "many\n")
+
 class TestPython3Mode:
     def test_p3_max(self, exec2):
         exec2("%python3\nmax([],default=9)", "9")


### PR DESCRIPTION
Ref: bug #1279 

- show ansi color codes in scala text output properly
- add `%scala211` built-in jupyter bridge mode and alias `%scala`
- add pytest for the two new modes
- remove commented-out `%r` mode code


```
~/smc/src/smc_sagews/smc_sagews/tests$ python -m pytest
...= 114 passed in 152.96 seconds =
```