### PR TITLE
Fix opening copied directories from log

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -2064,7 +2064,7 @@ exports.ProjectFiles = rclass ({name}) ->
             </div>
 
     update_current_listing: ->
-        setTimeout((=>@props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, @props.show_hidden)), 0)
+        setTimeout(@props.actions.fetch_directory_listing, 0)
 
     start_project: ->
         @actions('projects').start_project(@props.project_id)

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1320,7 +1320,12 @@ ProjectFilesActionBox = rclass
         destination_project_id = @state.copy_destination_project_id
         overwrite_newer        = @state.overwrite_newer
         delete_extra_files     = @state.delete_extra_files
-        paths = @props.checked_files.toArray()
+        f = (path) =>
+            if @props.displayed_listing?.file_map[misc.path_split(path).tail]?.isdir
+                return path + '/'
+            else
+                return path
+        paths = (f(path) for path in @props.checked_files.toArray())
         if destination_project_id? and @props.project_id isnt destination_project_id
             @props.actions.copy_paths_between_projects
                 public            : @props.public_view

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1122,18 +1122,10 @@ ProjectFilesActionBox = rclass
                     src  : @props.checked_files.toArray()
                     dest : misc.path_to_file(rename_dir, destination)
             when 'duplicate'
-                # Add a / after any directory names, so that the contents are copied, not the directory itself.
-                # Otherwise, we end up with copying foo to foo-1, resulting in a foo-1/foo/...
-                # See https://github.com/sagemathinc/smc/issues/1235
-                # Note that src has length 1 so the whole iteration business is overkill.
-                f = (path) =>
-                    if @props.displayed_listing?.file_map[misc.path_split(path).tail]?.isdir
-                        return path + '/'
-                    else
-                        return path
-                @props.actions.copy_files
-                    src  : (f(path) for path in @props.checked_files.toArray())
-                    dest : misc.path_to_file(rename_dir, destination)
+                @props.actions.copy_paths
+                    src           : @props.checked_files.toArray
+                    dest          : misc.path_to_file(rename_dir, destination)
+                    only_contents : true
         @props.actions.set_file_action()
         @props.actions.set_all_files_unchecked()
 
@@ -1320,12 +1312,7 @@ ProjectFilesActionBox = rclass
         destination_project_id = @state.copy_destination_project_id
         overwrite_newer        = @state.overwrite_newer
         delete_extra_files     = @state.delete_extra_files
-        f = (path) =>
-            if @props.displayed_listing?.file_map[misc.path_split(path).tail]?.isdir
-                return path + '/'
-            else
-                return path
-        paths = (f(path) for path in @props.checked_files.toArray())
+        paths                  = @props.checked_files.toArray()
         if destination_project_id? and @props.project_id isnt destination_project_id
             @props.actions.copy_paths_between_projects
                 public            : @props.public_view
@@ -1336,7 +1323,7 @@ ProjectFilesActionBox = rclass
                 overwrite_newer   : overwrite_newer
                 delete_missing    : delete_extra_files
         else
-            @props.actions.copy_files
+            @props.actions.copy_paths
                 src  : paths
                 dest : destination_directory
         @props.actions.set_file_action()

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -678,7 +678,7 @@ FileListing = rclass
 
         dropzone_handler =
             dragleave : (e) => @show_upload(e, false)
-            complete  : => @props.actions.set_directory_files(@props.current_path)
+            complete  : => @props.actions.fetch_directory_listing(@props.current_path)
 
         <div>
             {<Col sm=12 key='upload'>
@@ -739,24 +739,24 @@ ProjectFilesButtons = rclass
         if @props.default_sort != next.default_sort
             if next.default_sort == 'time' and next.sort_by_time is true or next.default_sort == 'name' and next.sort_by_time is false
                 @props.actions.setState(sort_by_time : next.sort_by_time)
-                @props.actions.set_directory_files(next.current_path, next.sort_by_time, next.show_hidden)
+                @props.actions.fetch_directory_listing(next.current_path, next.sort_by_time, next.show_hidden)
             else
                 @props.actions.setState(sort_by_time : not next.sort_by_time)
-                @props.actions.set_directory_files(next.current_path, not next.sort_by_time, next.show_hidden)
+                @props.actions.fetch_directory_listing(next.current_path, not next.sort_by_time, next.show_hidden)
 
     handle_refresh: (e) ->
         e.preventDefault()
-        @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)
+        @props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, @props.show_hidden)
 
     handle_sort_method: (e) ->
         e.preventDefault()
         @props.actions.setState(sort_by_time : not @props.sort_by_time)
-        @props.actions.set_directory_files(@props.current_path, not @props.sort_by_time, @props.show_hidden)
+        @props.actions.fetch_directory_listing(@props.current_path, not @props.sort_by_time, @props.show_hidden)
 
     handle_hidden_toggle: (e) ->
         e.preventDefault()
         @props.actions.setState(show_hidden : not @props.show_hidden)
-        @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, not @props.show_hidden)
+        @props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, not @props.show_hidden)
 
     render_refresh: ->
         <a href='' onClick={@handle_refresh}><Icon name='refresh' /> </a>
@@ -1071,7 +1071,7 @@ ProjectFilesActionBox = rclass
             paths : @props.checked_files.toArray()
         @props.actions.set_file_action()
         @props.actions.set_all_files_unchecked()
-        @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)
+        @props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, @props.show_hidden)
 
 
     render_delete_warning: ->
@@ -1888,7 +1888,7 @@ exports.ProjectFiles = rclass ({name}) ->
         @props.actions.setState(file_search : '', page_number: 0)
         if not switch_over
             # WARNING: Uses old way of refreshing file listing
-            @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)
+            @props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, @props.show_hidden)
 
     create_folder: (switch_over=true) ->
         @props.actions.create_folder
@@ -1898,7 +1898,7 @@ exports.ProjectFiles = rclass ({name}) ->
         @props.actions.setState(file_search : '', page_number: 0)
         if not switch_over
             # WARNING: Uses old way of refreshing file listing
-            @props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)
+            @props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, @props.show_hidden)
 
     render_paging_buttons: (num_pages) ->
         if num_pages > 1
@@ -2064,7 +2064,7 @@ exports.ProjectFiles = rclass ({name}) ->
             </div>
 
     update_current_listing: ->
-        setTimeout((=>@props.actions.set_directory_files(@props.current_path, @props.sort_by_time, @props.show_hidden)), 0)
+        setTimeout((=>@props.actions.fetch_directory_listing(@props.current_path, @props.sort_by_time, @props.show_hidden)), 0)
 
     start_project: ->
         @actions('projects').start_project(@props.project_id)

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1123,7 +1123,7 @@ ProjectFilesActionBox = rclass
                     dest : misc.path_to_file(rename_dir, destination)
             when 'duplicate'
                 @props.actions.copy_paths
-                    src           : @props.checked_files.toArray
+                    src           : @props.checked_files.toArray()
                     dest          : misc.path_to_file(rename_dir, destination)
                     only_contents : true
         @props.actions.set_file_action()

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -172,7 +172,7 @@ LogEntry = rclass
             when 'moved'
                 <span>moved {@multi_file_links(false)} {(if e.count? then "(#{e.count} total)" else '')} to {@file_link(e.dest, true, 0)}</span>
             when 'copied'
-                <span>copied {@multi_file_links()} {(if e.count? then "(#{e.count} total)" else '')} to {e.dest} {if e.project? then @project_title()}</span>
+                <span>copied {@multi_file_links()} {(if e.count? then "(#{e.count} total)" else '')} to {@file_link(e.dest, true)} {if e.project? then @project_title()}</span>
             when 'shared'
                 <span>shared {@multi_file_links()} {(if e.count? then "(#{e.count} total)" else '')}</span>
 

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -138,7 +138,7 @@ LogEntry = rclass
         <span>executed mini terminal command {@render_miniterm_command(@props.event.input)}</span>
 
     project_title: ->
-        <ProjectTitleAuto style={color:"#ffeb3b" if @props.cursor} project_id={@props.event.project} />
+        <ProjectTitleAuto style={if @props.cursor then selected_item} project_id={@props.event.project} />
 
     file_link: (path, link, i, project_id) ->
         <PathLink

--- a/src/smc-webapp/project_log.cjsx
+++ b/src/smc-webapp/project_log.cjsx
@@ -138,7 +138,7 @@ LogEntry = rclass
         <span>executed mini terminal command {@render_miniterm_command(@props.event.input)}</span>
 
     project_title: ->
-        <ProjectTitleAuto project_id={@props.event.project} />
+        <ProjectTitleAuto style={color:"#ffeb3b" if @props.cursor} project_id={@props.event.project} />
 
     file_link: (path, link, i, project_id) ->
         <PathLink
@@ -158,9 +158,7 @@ LogEntry = rclass
 
     to_link: ->
         e = @props.event
-        if e.project? and e.dest?
-            return <span>{@file_link(e.dest, true, 0, e.project)} of {@project_title()}</span>
-        else if e.project?
+        if e.project?
             return @project_title()
         else if e.dest?
             return @file_link(e.dest, true, 0)

--- a/src/smc-webapp/project_miniterm.cjsx
+++ b/src/smc-webapp/project_miniterm.cjsx
@@ -128,7 +128,7 @@ exports.MiniTerminal = MiniTerminal = rclass
                     if not output.stderr
                         # only log commands that worked...
                         @props.actions.log({event:'miniterm', input:input})
-                    @props.actions.set_directory_files()  # update directory listing (command may change files)
+                    @props.actions.fetch_directory_listing()  # update directory listing (command may change files)
                     @setState(state:'edit', error:output.stderr, stdout:output.stdout)
                     if not output.stderr
                         @setState(input:'')

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -367,7 +367,7 @@ ProjectMainContent = rclass
             when 'new'
                 <ProjectNew name={@props.project_name} project_id={@props.project_id} />
             when 'log'
-                <ProjectLog name={@props.project_name} />
+                <ProjectLog name={@props.project_name} project_id={@props.project_id} />
             when 'search'
                 <ProjectSearch name={@props.project_name} />
             when 'settings'

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -165,7 +165,7 @@ class ProjectActions extends Actions
                 @set_url_to_path(store.current_path ? '')
                 sort_by_time = store.sort_by_time
                 show_hidden = store.show_hidden
-                @set_directory_files(store.current_path, sort_by_time, show_hidden)
+                @fetch_directory_listing(store.current_path, sort_by_time, show_hidden)
             when 'new'
                 @setState(file_creation_error: undefined)
                 @push_state('new/' + store.current_path)
@@ -551,7 +551,7 @@ class ProjectActions extends Actions
             page_number            : 0
             most_recent_file_click : undefined
 
-        @set_directory_files()
+        @fetch_directory_listing()
 
     set_file_search: (search) =>
         @setState
@@ -563,7 +563,7 @@ class ProjectActions extends Actions
 
     # Update the directory listing cache for the given path
     # Use current path if path not provided
-    set_directory_files: (path, sort_by_time, show_hidden) =>
+    fetch_directory_listing: (path, sort_by_time, show_hidden) =>
         if not path?
             path = @get_store().current_path
         if not path?
@@ -745,7 +745,7 @@ class ProjectActions extends Actions
     _finish_exec: (id) =>
         # returns a function that takes the err and output and does the right activity logging stuff.
         return (err, output) =>
-            @set_directory_files()
+            @fetch_directory_listing()
             if err
                 @set_activity(id:id, error:err)
             else if output?.event == 'error' or output?.error
@@ -874,7 +874,7 @@ class ProjectActions extends Actions
             if err
                 @set_activity(id:id, error:err)
             else
-                @set_directory_files()
+                @fetch_directory_listing()
             @log
                 event  : 'file_action'
                 action : 'moved'
@@ -1050,7 +1050,7 @@ class ProjectActions extends Actions
             timeout : FROM_WEB_TIMEOUT_S
             alert   : true
             cb      : (err) =>
-                @set_directory_files()
+                @fetch_directory_listing()
                 @set_activity(id: id, stop:'')
                 cb?(err)
 

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -782,7 +782,6 @@ class ProjectActions extends Actions
             else
                 return path
 
-
     copy_paths: (opts) =>
         opts = defaults opts,
             src           : required     # Should be an array of source paths

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -849,7 +849,6 @@ class ProjectActions extends Actions
             action  : 'copied'
             files   : with_slashes[0...3]
             count   : if src.length > 3 then src.length
-            dest    : opts.target_path + '/'
             project : opts.target_project_id
         f = (src_path, cb) =>
             opts0 = misc.copy(opts)

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -523,6 +523,8 @@ class ProjectActions extends Actions
                 # TODO!
                 console.log('error opening directory in project: ', err, @project_id, path)
             else
+                if path[path.length - 1] == '/'
+                    path = path.slice(0, -1)
                 @foreground_project()
                 @set_current_path(path)
                 if @get_store().active_project_tab == 'files'
@@ -793,7 +795,7 @@ class ProjectActions extends Actions
             action : 'copied'
             files  : opts.src[0...3]
             count  : if opts.src.length > 3 then opts.src.length
-            dest   : opts.dest
+            dest   : opts.dest + '/'
         salvus_client.exec
             project_id      : @project_id
             command         : 'rsync'  # don't use "a" option to rsync, since on snapshots results in destroying project access!

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -157,13 +157,13 @@ class ProjectsActions extends Actions
         require('./project_store') # registers the project store with redux...
         store = redux.getProjectStore(opts.project_id)
         actions = redux.getProjectActions(opts.project_id)
-        sort_by_time = store.get('sort_by_time') ? true
-        show_hidden = store.get('show_hidden') ? false
+        sort_by_time = store.sort_by_time ? true
+        show_hidden = store.show_hidden ? false
 
         relation = redux.getStore('projects').get_my_group(opts.project_id)
         if not relation? or relation in ['public', 'admin']
             @fetch_public_project_title(opts.project_id)
-        actions.set_directory_files(store.get('current_path'), sort_by_time, show_hidden)
+        actions.fetch_directory_listing(store.current_path, sort_by_time, show_hidden)
         redux.getActions('page').set_active_tab(opts.project_id) if opts.switch_to
         @set_project_open(opts.project_id)
         if opts.target?

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -1447,15 +1447,16 @@ exports.ProjectsPage = ProjectsPage = rclass
         </div>
 
 exports.ProjectTitle = ProjectTitle = rclass
-    displayName : 'Projects-ProjectTitle'
+    displayName: 'Projects-ProjectTitle'
 
-    reduxProps :
+    reduxProps:
         projects :
             project_map : rtypes.immutable
 
-    propTypes :
+    propTypes:
         project_id   : rtypes.string.isRequired
         handle_click : rtypes.func
+        style        : rtypes.object
 
     shouldComponentUpdate: (nextProps) ->
         nextProps.project_map?.get(@props.project_id)?.get('title') != @props.project_map?.get(@props.project_id)?.get('title')
@@ -1465,17 +1466,21 @@ exports.ProjectTitle = ProjectTitle = rclass
             return <Loading />
         title = @props.project_map?.get(@props.project_id)?.get('title')
         if title?
-            <a onClick={@props.handle_click} href=''>{html_to_text(title)}</a>
+            <a onClick={@props.handle_click} style={@props.style} role='button'>{html_to_text(title)}</a>
         else
-            <span>(Private project)</span>
+            <span style={@props.style}>(Private project)</span>
 
 exports.ProjectTitleAuto = rclass
-    displayName : 'Projects-ProjectTitleAuto'
+    displayName: 'Projects-ProjectTitleAuto'
 
-    propTypes :
-        project_id  : rtypes.string.isRequired
+    propTypes:
+        project_id : rtypes.string.isRequired
+        style      : rtypes.object
+
+    handle_click: ->
+        @actions('projects').open_project(project_id : @props.project_id)
 
     render: ->
         <Redux redux={redux}>
-            <ProjectTitle project_id={@props.project_id} />
+            <ProjectTitle style={@props.style} project_id={@props.project_id} handle_click={@handle_click} />
         </Redux>

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -854,17 +854,19 @@ exports.SaveButton = rclass
             <Icon name='save' /> Sav{if @props.saving then <span>ing... <Icon name='circle-o-notch' spin /></span> else <span>e</span>}
         </Button>
 
-exports.FileLink = rclass
-    displayName : 'Misc-FileLink'
+# File link to attempt opening an smc path in a project
+# Assumes path ends in a / iff it is a directorie
+exports.PathLink = rclass
+    displayName : 'Misc-PathLink'
 
     propTypes :
         path         : rtypes.string.isRequired
+        project_id   : rtypes.string.isRequired
         display_name : rtypes.string # if provided, show this as the link and show real name in popover
         full         : rtypes.bool   # true = show full path, false = show only basename
         trunc        : rtypes.number # truncate longer names and show a tooltip with the full name
         style        : rtypes.object
         link         : rtypes.bool   # set to false to make it not be a link
-        actions      : rtypes.object.isRequired
 
     getDefaultProps: ->
         style : {}
@@ -873,12 +875,12 @@ exports.FileLink = rclass
 
     handle_click: (e) ->
         e.preventDefault()
-        if misc.endswith(@props.path, '/')
-            @props.actions.open_directory(@props.path)
-        else
-            @props.actions.open_file
-                path       : @props.path
-                foreground : misc.should_open_in_foreground(e)
+        path_head = 'files'
+        path_head += '/' if @props.path[0] != '/'
+        @actions('projects').open_project
+            project_id : @props.project_id
+            target     : path_head + @props.path
+            switch_to  : misc.should_open_in_foreground(e)
 
     render_link: (text) ->
         if @props.link

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -854,8 +854,7 @@ exports.SaveButton = rclass
             <Icon name='save' /> Sav{if @props.saving then <span>ing... <Icon name='circle-o-notch' spin /></span> else <span>e</span>}
         </Button>
 
-# File link to attempt opening an smc path in a project
-# Assumes path ends in a / iff it is a directorie
+# Compnent to attempt opening an smc path in a project
 exports.PathLink = rclass
     displayName : 'Misc-PathLink'
 

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -880,7 +880,6 @@ exports.FileLink = rclass
                 path       : @props.path
                 foreground : misc.should_open_in_foreground(e)
 
-
     render_link: (text) ->
         if @props.link
             <a onClick={@handle_click} style={@props.style} href=''>{text}</a>

--- a/src/smc-webapp/r_upgrades.cjsx
+++ b/src/smc-webapp/r_upgrades.cjsx
@@ -2,37 +2,11 @@
 {Loading, r_join, Space, Footer} = require('./r_misc')
 misc = require('smc-util/misc')
 {Button, Row, Col, Well, Panel, ProgressBar} = require('react-bootstrap')
-{ProjectTitle} = require('./projects') # SMELL: ProjectTitle is left undefined after this..
 {HelpEmailLink, SiteName, PolicyPricingPageUrl} = require('./customize')
 
 {PROJECT_UPGRADES} = require('smc-util/schema')
 
 round1 = misc.round1
-
-# WARNING: ProjectTitle is required above
-{html_to_text} = require('./misc_page')
-ProjectTitle = rclass
-    displayName : 'Projects-ProjectTitle'
-
-    reduxProps :
-        projects :
-            project_map : rtypes.immutable
-
-    propTypes :
-        project_id   : rtypes.string.isRequired
-        handle_click : rtypes.func
-
-    shouldComponentUpdate: (nextProps) ->
-        nextProps.project_map?.get(@props.project_id)?.get('title') != @props.project_map?.get(@props.project_id)?.get('title')
-
-    render: ->
-        if not @props.project_map?
-            return <Loading />
-        title = @props.project_map?.get(@props.project_id)?.get('title')
-        if title?
-            <a onClick={@props.handle_click} href=''>{html_to_text(title)}</a>
-        else
-            <span>(Private project)</span>
 
 exports.UpgradesPage = rclass
     propTypes :
@@ -160,6 +134,7 @@ exports.UpgradesPage = rclass
         return r_join(v)
 
     render_upgraded_project: (project_id, upgrades, darker) ->
+        {ProjectTitle} = require('./projects')
         <Row key={project_id} style={backgroundColor:'#eee' if darker}>
             <Col sm=4>
                 <ProjectTitle


### PR DESCRIPTION
Fixes #1326. 

In my opinion, this isn't the prettiest solution, but a better solution (I would rather all folder paths end with `/`) is *much* more involved with a *lot* more testing. #1330 proposes this change.