### PR TITLE
webapp/editor/mode: showing mode button for sagews editor -- #1337

### DIFF
--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -499,7 +499,7 @@ code
 
 .salvus-editor-codeedit-buttonbar-mode
   background : #fafafa
-  padding    : 4px
+  padding    : 6px 12px
   border     : 1px solid #ddd
   cursor     : pointer
   color      : darkblue

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1731,7 +1731,7 @@ class CodeMirrorEditor extends FileEditor
         @element.find(".sagews-output-editor-foreground-color-selector").hide()
         @element.find(".sagews-output-editor-background-color-selector").hide()
 
-        @fallback_buttons.find("a[href=\"#todo\"]").click () =>
+        @fallback_buttons.find('a[href="#todo"]').click () =>
             bootbox.alert("<i class='fa fa-wrench' style='font-size: 18pt;margin-right: 1em;'></i> Button bar not yet implemented in <code>#{mode_display.text()}</code> cells.")
             return false
 
@@ -1741,6 +1741,7 @@ class CodeMirrorEditor extends FileEditor
 
         @mode_display = mode_display = @element.find(".salvus-editor-codeedit-buttonbar-mode")
         @_current_mode = "sage"
+        @mode_display.show()
 
         set_mode_display = (name) =>
             #console.log("set_mode_display: #{name}")


### PR DESCRIPTION
solution to #1337 by showing it when the buttons are initialized. also, changing the style to be similar to with the other buttons.