### PR TITLE
warn about non-ascii characters in code if there is an error #1349

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -919,6 +919,14 @@ class Salvus(object):
 
     def execute(self, code, namespace=None, preparse=True, locals=None):
 
+        ascii_warn = False
+        code_error = False
+        if sys.getdefaultencoding() == 'ascii':
+            for c in code:
+                if ord(c) >= 128:
+                    ascii_warn = True
+                    break
+
         if namespace is None:
             namespace = self.namespace
 
@@ -969,11 +977,15 @@ class Salvus(object):
                 sys.stdout.flush()
                 sys.stderr.flush()
             except:
+                code_error = True
                 sys.stdout.flush()
                 sys.stderr.write('Error in lines %s-%s\n'%(start+1, stop+1))
                 traceback.print_exc()
                 sys.stderr.flush()
                 break
+        if code_error and ascii_warn:
+            sys.stderr.write('*** WARNING: Code contains non-ascii characters ***\n')
+            sys.stderr.flush()
 
     def execute_with_code_decorators(self, code_decorators, code, preparse=True, namespace=None, locals=None):
         """


### PR DESCRIPTION
Ref: #1349 

How does this look? I didn't add pytest cases yet because I'm not sure the test is specific enough.
Example:
```
# code with non-printing characters
def f():
    a = [0]
    a[0]
---
Error in lines 3-3
Traceback (most recent call last):
  File "/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/.local/lib/python2.7/site-packages/smc_sagews/sage_server.py", line 977, in execute
    exec compile(block+'\n', '', 'single') in namespace, locals
  File "", line 1, in <module>
NameError: name 'a' is not defined
*** WARNING: Code contains non-ascii characters ***
```

