### PR TITLE
webapp/interact: wrapping options of selectors in jquery -- fixes #1354

### DIFF
--- a/src/smc-webapp/interact.coffee
+++ b/src/smc-webapp/interact.coffee
@@ -476,6 +476,7 @@ interact_control = (desc, update, process_html_output) ->
                     else
                         val = String(val)
                         for opt in select.find("option")
+                            opt = $(opt)
                             if opt.attr("value") == val
                                 opt.attr("selected", true)
         else


### PR DESCRIPTION
I don't know why this was broken, but wrapping again in jquery fixes #1354 