### PR TITLE
webapp: set public html iframe srcdoc when supported -- #1347

### DIFF
--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -356,7 +356,7 @@
 
 .salvus-editor-static-html-content
   overflow-y : auto
-  margin     : 1em
+  margin     : 0
   border-top : 1px solid lightgray
 
 

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -2851,6 +2851,8 @@ class PublicHTML extends FileEditor
     constructor: (@project_id, @filename, @content, opts) ->
         super(@project_id, @filename)
         @element = templates.find(".salvus-editor-static-html").clone()
+        # ATTN: we can't set src='raw-path' because the sever might not run.
+        # therefore we retrieve the content and set it directly.
         if not @content?
             @content = 'Loading...'
             # Now load the content from the backend...
@@ -2884,7 +2886,13 @@ class PublicHTML extends FileEditor
         # We do this, since otherwise just loading the iframe using
         #      @iframe.contents().find('html').html(@content)
         # messes up the parent html page...
-        @iframe.contents().find('body')[0].innerHTML = @content
+        # ... but setting the innerHTML=@content causes issue 1347!
+        # A compromise is to set the 'srcdoc' attribute to the content,
+        # but that doesn't work in IE/Edge -- http://caniuse.com/#search=srcdoc
+        if $.browser.edge or $.browser.ie
+            @iframe.contents().find('body').html(@content)
+        else
+            @iframe.attr('srcdoc', @content)
         @iframe.contents().find('body').find("a").attr('target','_blank')
         @iframe.maxheight()
 

--- a/src/smc-webapp/feature.coffee
+++ b/src/smc-webapp/feature.coffee
@@ -68,6 +68,7 @@ $.browser.firefox = not $.browser.chrome and user_agent.indexOf('firefox') > 0
 $.browser.safari  = not $.browser.chrome and user_agent.indexOf('safari') > 0
 $.browser.ie      = not $.browser.chrome and user_agent.indexOf('windows') > 0
 $.browser.blink   = ($.browser.chrome || $.browser.opera) && !!window.CSS
+$.browser.edge    = /Edge\/\d./i.test(navigator.userAgent)
 
 exports.get_browser = () ->
     for k, v of $.browser


### PR DESCRIPTION
This is the best I came up with for #1347. The root problem is, that setting the innerHTML in an iframe doesn't trigger any javascript to run. Maybe that's a security measure, I don't know (even a `console.log` in a script tag doesn't work) and therefore no mathjax.

However, setting the srcdoc works in almost all browsers and this falls back to jquery's `html(...)` for the other ones.

Besides that: It removes a margin which make no sense.