### PR TITLE
Always render \$ as $.

### DIFF
--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -713,7 +713,7 @@ exports.Markdown = rclass
 
     update_escaped_chars: ->
         node = $(ReactDOM.findDOMNode(@))
-        node.text(node[0].innerText.replace(/\\\$/g, '$'))
+        node.html(node[0].innerHTML.replace(/\\\$/g, '$'))
 
     update_mathjax: ->
         if @_x?.has_mathjax?

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -711,6 +711,10 @@ exports.Markdown = rclass
     shouldComponentUpdate: (newProps) ->
         return @props.value != newProps.value or not underscore.isEqual(@props.style, newProps.style)
 
+    update_escaped_chars: ->
+        node = $(ReactDOM.findDOMNode(@))
+        node.text(node[0].innerText.replace(/\\\$/g, '$'))
+
     update_mathjax: ->
         if @_x?.has_mathjax?
             $(ReactDOM.findDOMNode(@)).mathjax()
@@ -721,10 +725,12 @@ exports.Markdown = rclass
     componentDidUpdate: ->
         @update_links()
         @update_mathjax()
+        @update_escaped_chars()
 
     componentDidMount: ->
         @update_links()
         @update_mathjax()
+        @update_escaped_chars()
 
     to_html: ->
         if @props.value


### PR DESCRIPTION
Fixes #1329 in all markdown renderers which use the `r_misc.Markdown` component. 