### PR TITLE
Force refresh on logout

### DIFF
--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -321,7 +321,7 @@ AccountSettings = rclass
         if field in ['first_name', 'last_name'] and not value and (not @props.first_name or not @props.last_name)
             # special case -- don't let them make their name empty -- that's just annoying (not enforced server side)
             return
-        @props.redux.getActions('account').setState("#{field}": value)
+        @actions('account').setState("#{field}": value)
 
     save_change: (evt, field) ->
         value = evt.target.value
@@ -404,7 +404,7 @@ AccountSettings = rclass
             </Button>
 
     render_sign_out_error: ->
-        <ErrorDisplay error={@props.sign_out_error} onClose={=>@props.redux.getActions('account').setState(sign_out_error : '')} />
+        <ErrorDisplay error={@props.sign_out_error} onClose={=>@actions('account').setState(sign_out_error : '')} />
 
     render_sign_out_confirm: ->
         if @props.everywhere
@@ -414,10 +414,10 @@ AccountSettings = rclass
         <Well style={marginTop: '15px'}>
             {text}
             <ButtonToolbar style={textAlign: 'center', marginTop: '15px'}>
-                <Button bsStyle="primary" onClick={=>@props.redux.getActions('account').sign_out(@props.everywhere)}>
+                <Button bsStyle="primary" onClick={=>@actions('account').sign_out(@props.everywhere)}>
                     <Icon name="external-link" /> Sign out
                 </Button>
-                <Button onClick={=>@props.redux.getActions('account').setState(show_sign_out : false)}} >
+                <Button onClick={=>@actions('account').setState(show_sign_out : false)}} >
                     Cancel
                 </Button>
             </ButtonToolbar>
@@ -427,11 +427,11 @@ AccountSettings = rclass
     render_sign_out_buttons: ->
         <ButtonToolbar className='pull-right'>
             <Button bsStyle='warning' disabled={@props.show_sign_out and not @props.everywhere}
-                onClick={=>@props.redux.getActions('account').setState(show_sign_out : true, everywhere : false)}>
+                onClick={=>@actions('account').setState(show_sign_out : true, everywhere : false)}>
                 <Icon name='sign-out'/> Sign out...
             </Button>
             <Button bsStyle='warning' disabled={@props.show_sign_out and @props.everywhere}
-                onClick={=>@props.redux.getActions('account').setState(show_sign_out : true, everywhere : true)}>
+                onClick={=>@actions('account').setState(show_sign_out : true, everywhere : true)}>
                 <Icon name='sign-out'/> Sign out everywhere...
             </Button>
         </ButtonToolbar>
@@ -486,7 +486,7 @@ AccountSettings = rclass
                     <DeleteAccount
                         style={marginTop:'1ex'}
                         initial_click = {()=>@setState(show_delete_confirmation:true)}
-                        confirm_click = {=>@props.redux.getActions('account').delete_account()}
+                        confirm_click = {=>@actions('account').delete_account()}
                         cancel_click  = {()=>@setState(show_delete_confirmation:false)}
                         user_name     = {@props.first_name + ' ' + @props.last_name}
                         show_confirmation={@state.show_delete_confirmation}

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -146,6 +146,7 @@ class AccountActions extends Actions
                     # Force a refresh, since otherwise there could be data
                     # left in the DOM, which could lead to a vulnerability
                     # or bleed into the next login somehow.
+                    $(window).off('beforeunload', redux.getActions('page').check_unload)
                     window.location.reload(false)
 
     push_state: (url) =>

--- a/src/smc-webapp/redux_account.coffee
+++ b/src/smc-webapp/redux_account.coffee
@@ -145,7 +145,7 @@ class AccountActions extends Actions
                 else
                     # Force a refresh, since otherwise there could be data
                     # left in the DOM, which could lead to a vulnerability
-                    # or blead into the next login somehow.
+                    # or bleed into the next login somehow.
                     window.location.reload(false)
 
     push_state: (url) =>


### PR DESCRIPTION
Turns out I broke forced refresh in the react rewrite. 

Currently if you have this option checked
![other settings](https://cloud.githubusercontent.com/assets/618575/21205124/61044fa0-c20f-11e6-8b52-9475d48f6d52.png)

and you sign out, failing tell the page to reload will allow anyone to **log onto your account with their own credentials**.