### PR TITLE
make test function names unique, fix typo

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/test_graphics.py
+++ b/src/smc_sagews/smc_sagews/tests/test_graphics.py
@@ -12,7 +12,7 @@ class TestGraphics:
         execblob("plot(cos(x),x,0,pi)", want_html = False, file_type = 'svg')
 
 class TestOctavePlot:
-    def test_plot(self,execblob):
+    def test_octave_plot(self,execblob):
         # assume octave kernel not running at start of test
         execblob("%octave\nx = -10:0.1:10;plot (x, sin (x));", file_type = 'png')
 

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -67,7 +67,7 @@ class TestBasic:
         code = "os.chdir(salvus.data[\'path\']);__file__=salvus.data[\'file\']"
         exec2(code)
 
-    def test_assignment(self, exec2):
+    def test_sage_assignment(self, exec2):
         code = "x = 42\nx\n"
         output = "42\n"
         exec2(code, output)

--- a/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews_modes.py
@@ -122,37 +122,37 @@ class TestShMode:
         exec2("%sh xyz", pattern="command not found")
 
 class TestShDefaultMode:
-    def test_start_sh(self, exec2):
+    def test_start_sh_dflt(self, exec2):
         exec2("%default_mode sh")
     def test_start_sh2(self, exec2):
         exec2("who -b", pattern="system boot")
 
-    def test_multiline(self, exec2):
+    def test_multiline_dflt(self, exec2):
         exec2("FOO=hello\necho $FOO", pattern="^hello")
 
     def test_date(self, exec2):
         exec2("date +%Y-%m-%d", pattern = r'^\d{4}-\d{2}-\d{2}')
 
-    def test_capture_sh_01(self, exec2):
+    def test_capture_sh_01_dflt(self, exec2):
         exec2("%capture(stdout='output')\nuptime")
-    def test_capture_sh_02(self, exec2):
+    def test_capture_sh_02_dflt(self, exec2):
         exec2("%sage\noutput", pattern="up.*user.*load average")
 
-    def test_remember_settings_01(self, exec2):
+    def test_remember_settings_01_dflt(self, exec2):
         exec2("FOO='testing123'")
-    def test_remember_settings_02(self, exec2):
+    def test_remember_settings_02_dflt(self, exec2):
         exec2("echo $FOO", pattern=r"^testing123\s+")
 
-    def test_sh_display(self, execblob, image_file):
+    def test_sh_display_dflt(self, execblob, image_file):
         execblob("display < " + str(image_file), want_html=False)
 
-    def test_sh_autocomplete_01(self, exec2):
+    def test_sh_autocomplete_01_dflt(self, exec2):
         exec2("TESTVAR29=xyz")
-    def test_sh_autocomplete_02(self, execintrospect):
+    def test_sh_autocomplete_02_dflt(self, execintrospect):
         execintrospect('echo $TESTV', ["AR29"], '$TESTV')
 
 class TestRMode:
-    def test_assignment(self, exec2):
+    def test_r_assignment(self, exec2):
         exec2("%r\nxx <- c(4,7,13)\nmean(xx)", html_pattern="^8$")
 
     def test_r_version(self, exec2):
@@ -166,12 +166,12 @@ class TestRMode:
 class TestRDefaultMode:
     def test_set_r_mode(self, exec2):
         exec2("%default_mode r")
-    def test_assignment(self, exec2):
+    def test_rdflt_assignment(self, exec2):
         exec2("xx <- c(4,7,13)\nmean(xx)", html_pattern="^8$")
 
-    def test_capture_r_01(self, exec2):
+    def test_dflt_capture_r_01(self, exec2):
         exec2("%capture(stdout='output')\nsum(xx)")
-    def test_capture_r_02(self, exec2):
+    def test_dflt_capture_r_02(self, exec2):
         exec2("%sage\nprint(output)", "24\n")
 
 class TestRWD:
@@ -226,7 +226,7 @@ class TestAnaconda3Mode:
     def test_issue_862(self, exec2):
         exec2('%a3\nx=1\nprint("x = %s" % x)\nx','x = 1\n')
 
-    def test_a3_errror(self, exec2):
+    def test_a3_error(self, exec2):
         exec2('%a3\nxyz*', html_pattern = 'span style.*color')
 
 class TestSageMode:


### PR DESCRIPTION
Unique test function names will make it easier to work with the `sagews-test-report.json` test results report.