### PR TITLE
Issue/1391

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -116,8 +116,6 @@ $.fn.process_smc_links = (opts={}) ->
     @each ->
         e = $(this)
         a = e.find('a')
-        # make links open in a new tab by default
-        a.attr("target","_blank")
         for x in a
             y = $(x)
             href = y.attr('href')
@@ -137,6 +135,7 @@ $.fn.process_smc_links = (opts={}) ->
                     # internal link
                     y.click (e) ->
                         target = $(@).attr('href')
+                        {join} = require('path')
                         if target.indexOf('/projects/') == 0
                             # fully absolute (but without https://...)
                             target = decodeURI(target.slice('/projects/'.length))
@@ -145,12 +144,15 @@ $.fn.process_smc_links = (opts={}) ->
                             target = decodeURI(target.slice(1))  # just get rid of leading slash
                         else if target[0] == '/' and opts.project_id
                             # absolute inside of project
-                            target = "#{opts.project_id}/files#{decodeURI(target)}"
+                            target = join(opts.project_id, 'files', decodeURI(target))
                         else if opts.project_id and opts.file_path?
                             # realtive to current path
-                            target = "#{opts.project_id}/files/#{opts.file_path}/#{decodeURI(target)}"
+                            target = join(opts.project_id, 'files', opts.file_path, decodeURI(target))
                         redux.getActions('projects').load_target(target, not(e.which==2 or (e.ctrlKey or e.metaKey)))
                         return false
+                else
+                    # make links open in a new tab by default
+                    a.attr("target","_blank")
 
         # make relative links to images use the raw server
         if opts.project_id and opts.file_path?

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -160,7 +160,8 @@ $.fn.process_smc_links = (opts={}) ->
                 src = y.attr('src')
                 if src.indexOf('://') != -1
                     continue
-                new_src = "/#{opts.project_id}/raw/#{opts.file_path}/#{src}"
+                {join} = require('path')
+                new_src = join('/', window.smc_base_url, opts.project_id, 'raw', opts.file_path, src)
                 y.attr('src', new_src)
 
         return e

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -723,14 +723,14 @@ exports.Markdown = rclass
         $(ReactDOM.findDOMNode(@)).process_smc_links(project_id:@props.project_id, file_path:@props.file_path)
 
     componentDidUpdate: ->
-        @update_links()
         @update_mathjax()
         @update_escaped_chars()
+        @update_links()
 
     componentDidMount: ->
-        @update_links()
         @update_mathjax()
         @update_escaped_chars()
+        @update_links()
 
     to_html: ->
         if @props.value

--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -1272,9 +1272,6 @@ class SynchronizedWorksheet extends SynchronizedDocument2
         # handle a links
         a = e.find('a')
 
-        # make links open in a new tab
-        a.attr("target","_blank")
-
         that = @
         for x in a
             y = $(x)
@@ -1313,6 +1310,9 @@ class SynchronizedWorksheet extends SynchronizedDocument2
                             target = join(that.project_id, 'files', that.file_path(), decodeURI(target))
                         redux.getActions('projects').load_target(target, not(e.which==2 or (e.ctrlKey or e.metaKey)))
                         return false
+                else
+                    # make links open in a new tab
+                    a.attr("target","_blank")
 
         # make relative links to images use the raw server
         a = e.find("img")

--- a/src/smc-webapp/sagews.coffee
+++ b/src/smc-webapp/sagews.coffee
@@ -1298,6 +1298,7 @@ class SynchronizedWorksheet extends SynchronizedDocument2
                     # internal link
                     y.click (e) ->
                         target = $(@).attr('href')
+                        {join} = require('path')
                         if target.indexOf('/projects/') == 0
                             # fully absolute (but without https://...)
                             target = decodeURI(target.slice('/projects/'.length))
@@ -1306,10 +1307,10 @@ class SynchronizedWorksheet extends SynchronizedDocument2
                             target = decodeURI(target.slice(1))  # just get rid of leading slash
                         else if target[0] == '/'
                             # absolute inside of project
-                            target = "#{that.project_id}/files#{decodeURI(target)}"
+                            target = join(that.project_id, 'files', decodeURI(target))
                         else
                             # relative to current path
-                            target = "#{that.project_id}/files/#{that.file_path()}/#{decodeURI(target)}"
+                            target = join(that.project_id, 'files', that.file_path(), decodeURI(target))
                         redux.getActions('projects').load_target(target, not(e.which==2 or (e.ctrlKey or e.metaKey)))
                         return false
 
@@ -1341,7 +1342,8 @@ class SynchronizedWorksheet extends SynchronizedDocument2
             file_path = @file_path()
             if misc.startswith(src, '/')
                 file_path = ".smc/root/#{file_path}"
-            new_src = "#{window.smc_base_url}/#{@project_id}/raw/#{file_path}/#{src}"
+            {join} = require('path')
+            new_src = join(window.smc_base_url, @project_id, 'raw', file_path, src)
             y.attr('src', new_src)
 
     _post_save_success: () =>


### PR DESCRIPTION
this fixes #1391 and some extras

* be explicit about when target="_blank"
* support base url for relative images in chat (i.e.  for smc-in-smc)
* fix links in the root directory in markdown in sagews, i.e. when the path is just a `""`, the string concatenation for the href would introduce two `...//...` in the URL. `join` takes care of that.