### PR TITLE
webapp/hub: setting reply-to in emails such that recipients automatically contact the correct one

### DIFF
--- a/src/smc-hub/hub.coffee
+++ b/src/smc-hub/hub.coffee
@@ -1230,20 +1230,21 @@ class Client extends EventEmitter
 
                             # asm_group: 699 is for invites https://app.sendgrid.com/suppressions/advanced_suppression_manager
                             opts =
-                                to       : email_address
-                                bcc      : 'invites@sagemath.com'
-                                fromname : 'SageMathCloud'
-                                from     : 'invites@sagemath.com'
-                                replyto  : 'help@sagemath.com'
-                                subject  : subject
-                                category : "invite"
-                                asm_group: 699
-                                body     : email + """<br/><br/>
-                                           <b>To accept the invitation, please sign up at
-                                           <a href='#{base_url}'>#{base_url}</a>
-                                           using exactly the email address '#{email_address}'.
-                                           #{direct_link}</b><br/>"""
-                                cb       : (err) =>
+                                to           : email_address
+                                bcc          : 'invites@sagemath.com'
+                                fromname     : 'SageMathCloud'
+                                from         : 'invites@sagemath.com'
+                                replyto      : mesg.replyto ? 'help@sagemath.com'
+                                replyto_name : mesg.replyto_name
+                                subject      : subject
+                                category     : "invite"
+                                asm_group    : 699
+                                body         : email + """<br/><br/>
+                                               <b>To accept the invitation, please sign up at
+                                               <a href='#{base_url}'>#{base_url}</a>
+                                               using exactly the email address '#{email_address}'.
+                                               #{direct_link}</b><br/>"""
+                                cb           : (err) =>
                                     if err
                                         winston.debug("FAILED to send email to #{email_address}  -- err={misc.to_json(err)}")
                                     database.sent_project_invite

--- a/src/smc-hub/package.json
+++ b/src/smc-hub/package.json
@@ -41,7 +41,7 @@
     "require-reload": "^0.2.2",
     "rethinkdb": "^2.3.1",
     "rimraf": "^2.4.4",
-    "sendgrid": "^1.9.2",
+    "sendgrid": "^4.7.1",
     "start-stop-daemon": "^0.1.1",
     "stripe": "^4.0.0",
     "temp": "^0.8.3",

--- a/src/smc-util/client.coffee
+++ b/src/smc-util/client.coffee
@@ -903,22 +903,26 @@ class exports.Connection extends EventEmitter
 
     invite_noncloud_collaborators: (opts) =>
         opts = defaults opts,
-            project_id : required
-            title      : required
-            link2proj  : required
-            to         : required
-            email      : required   # body in HTML format
-            subject    : undefined
-            cb         : required
+            project_id   : required
+            title        : required
+            link2proj    : required
+            replyto      : undefined
+            replyto_name : undefined
+            to           : required
+            email        : required   # body in HTML format
+            subject      : undefined
+            cb           : required
 
         @call
             message: message.invite_noncloud_collaborators
-                project_id : opts.project_id
-                title      : opts.title
-                link2proj  : opts.link2proj
-                email      : opts.email
-                to         : opts.to
-                subject    : opts.subject
+                project_id    : opts.project_id
+                title         : opts.title
+                link2proj     : opts.link2proj
+                email         : opts.email
+                replyto       : opts.replyto
+                replyto_name  : opts.replyto_name
+                to            : opts.to
+                subject       : opts.subject
             cb : (err, resp) =>
                 if err
                     opts.cb(err)

--- a/src/smc-util/message.coffee
+++ b/src/smc-util/message.coffee
@@ -635,14 +635,16 @@ message
     account_id : required
 
 message
-    event      : 'invite_noncloud_collaborators'
-    id         : undefined
-    project_id : required
-    to         : required
-    subject    : undefined
-    email      : required    # spam vector
-    title      : required
-    link2proj  : required
+    event         : 'invite_noncloud_collaborators'
+    id            : undefined
+    project_id    : required
+    replyto       : undefined
+    replyto_name  : undefined
+    to            : required
+    subject       : undefined
+    email         : required    # spam vector
+    title         : required
+    link2proj     : required
 
 message
     event      : 'invite_noncloud_collaborators_resp'

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -476,14 +476,16 @@ init_redux = (course_filename, redux, course_project_id) ->
             s = get_store()
             body = s.get_email_invite()
             invite = (x) ->
+                account_store = redux.getStore('account')
+                name    = account_store.get_fullname()
+                replyto = account_store.get_email_address()
                 if '@' in x
                     if not do_not_invite_student_by_email
                         title   = s.getIn(['settings', 'title'])
                         subject = "SageMathCloud Invitation to Course #{title}"
-                        name    = redux.getStore('account').get_fullname()
                         body    = body.replace(/{title}/g, title).replace(/{name}/g, name)
                         body    = markdownlib.markdown_to_html(body).s
-                        redux.getActions('projects').invite_collaborators_by_email(student_project_id, x, body, subject, true)
+                        redux.getActions('projects').invite_collaborators_by_email(student_project_id, x, body, subject, true, replyto, name)
                 else
                     redux.getActions('projects').invite_collaborator(student_project_id, x)
             # Make sure the student is on the student's project:

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -832,11 +832,16 @@ CollaboratorsSearch = rclass
         @setState(email_to: @state.search, email_body: body)
 
     send_email_invite: ->
-        subject = "SageMathCloud Invitation to #{@props.project.get('title')}"
+        subject      = "SageMathCloud Invitation to #{@props.project.get('title')}"
+        replyto      = redux.getStore('account').get_email_address()
+        replyto_name = redux.getStore('account').get_fullname()
         @actions('projects').invite_collaborators_by_email(@props.project.get('project_id'),
                                                                          @state.email_to,
                                                                          @state.email_body,
-                                                                         subject)
+                                                                         subject,
+                                                                         false,
+                                                                         replyto,
+                                                                         replyto_name)
         @setState(email_to:'',email_body:'')
 
     render_send_email: ->

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -287,9 +287,9 @@ class ProjectsActions extends Actions
                     err = "Error inviting collaborator #{account_id} from #{project_id} -- #{err}"
                     alert_message(type:'error', message:err)
 
-    invite_collaborators_by_email: (project_id, to, body, subject, silent) =>
+    invite_collaborators_by_email: (project_id, to, body, subject, silent, replyto, replyto_name) =>
         @redux.getProjectActions(project_id).log
-            event    : 'invite_nonuser'
+            event         : 'invite_nonuser'
             invitee_email : to
         title = @redux.getStore('projects').get_title(project_id)
         if not body?
@@ -302,13 +302,15 @@ class ProjectsActions extends Actions
         body = markdown.markdown_to_html(body).s
 
         salvus_client.invite_noncloud_collaborators
-            project_id : project_id
-            title      : title
-            link2proj  : link2proj
-            to         : to
-            email      : body
-            subject    : subject
-            cb         : (err, resp) =>
+            project_id   : project_id
+            title        : title
+            link2proj    : link2proj
+            replyto      : replyto
+            replyto_name : replyto_name
+            to           : to
+            email        : body
+            subject      : subject
+            cb           : (err, resp) =>
                 if not silent
                     if err
                         alert_message(type:'error', message:err)


### PR DESCRIPTION
(unless email_address is undefined, then it falls back) and updating the sendgrid API to v3. -- issue #1316

for testing: update the sendgrid npm package, then send an invitation email and a course invite. in both cases, the normal "reply" in the email will be the actual user, not help@sagemath.com. also, in gmail, when clicking on "show original" in the email's drop down, SPF and DKIM both pass.