### PR TITLE
Issue/1412 -- making mathjax in chat great again

### DIFF
--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -589,3 +589,6 @@ h6 { font-size: 110% }
 
 .smc-message-from-viewer a:link, .smc-message-from-viewer a:visited
    color : #FFEB3B
+
+.smc-chat-message img
+  max-width: 100%

--- a/src/smc-webapp/side_chat.cjsx
+++ b/src/smc-webapp/side_chat.cjsx
@@ -217,7 +217,7 @@ Message = rclass
 
         <Col key={1} xs={11} style={width: "100%"}>
             {show_user_name(@props.sender_name) if not @props.is_prev_sender and not sender_is_viewer(@props.account_id, @props.message)}
-            <Well style={message_style} bsSize="small" onDoubleClick = {@edit_message}>
+            <Well style={message_style} bsSize="small" className="smc-chat-message"  onDoubleClick = {@edit_message}>
                 <span style={lighten}>
                     {editor_chat.render_timeago(@props.message)}
                 </span>

--- a/src/smc-webapp/smc_chat.cjsx
+++ b/src/smc-webapp/smc_chat.cjsx
@@ -270,7 +270,7 @@ Message = rclass
 
         <Col key={1} xs={10} sm={9}>
             {show_user_name(@props.sender_name) if not @props.is_prev_sender and not sender_is_viewer(@props.account_id, @props.message)}
-            <Well style={message_style} bsSize="small" onDoubleClick = {@edit_message}>
+            <Well style={message_style} className="smc-chat-message" bsSize="small" onDoubleClick = {@edit_message}>
                 <span style={lighten}>
                     {editor_chat.render_timeago(@props.message)}
                 </span>


### PR DESCRIPTION
This is a fix for the failing mathjax processing. It also cleans up odd things with html sanitizing and only calls mathjax if the markdown processing told it that there are formulas (right now, it would do it for all messages or never)

Things to test
* lines like `xyz \$1+2+3+4\$ asdf $4^2$ $100` ← `\$` should show up as `$` while 4^2 and the dollar amount works.
* still sanitizing html (but not `inside code blocks`)

I also sneaked in a max-width of 100% for images ... was always bugging me