### PR TITLE
webapp/files: fix path for root directories

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -708,11 +708,18 @@ ProjectFilesPath = rclass
         v.push <PathSegmentLink path='' display={<Icon name='home' />} key='home' actions={@props.actions} />
         if @props.current_path == ""
             return v
-        path = @props.current_path.split('/')
-        for segment, i in path
-            v.push <span key={2 * i + 1}><Space/> / <Space/></span>
+        path = @props.current_path
+        root = path[0] == '/'
+        if root
+            path = path[1..]
+        path_segments = path.split('/')
+        for segment, i in path_segments
+            if i == 0 and root
+                v.push <span key={2 * i + 1}><span style={width: '2em', display:'inline-block'}>&nbsp;</span>/<Space/></span>
+            else
+                v.push <span key={2 * i + 1}><Space/>/<Space/></span>
             v.push <PathSegmentLink
-                    path      = {path[0...i + 1].join('/')}
+                    path      = {path_segments[..i].join('/')}
                     display   = {misc.trunc_middle(segment, 15)}
                     full_name = {segment}
                     key       = {2 * i + 2}


### PR DESCRIPTION
see  issue #1414

this is a proposal for how to deal with that situation. it basically checks, if the path is an absolute directory (when opening that directory mentioned in #1414, `readlink -f` shows that it is really a root directory)

"logical" would be to get rid of the home "house" icon, but I don't like doing that. therefore, it adds a bit of extra space to distance it.