### PR TITLE
issue/1424 Rmd edit mode 

### DIFF
--- a/src/smc-webapp/editor-html-md/editor-html-md.coffee
+++ b/src/smc-webapp/editor-html-md/editor-html-md.coffee
@@ -54,6 +54,8 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             @opts.mode = 'htmlmixed'
         else if @ext == 'md'
             @opts.mode = 'gfm'
+        else if @ext == 'rmd'
+            @opts.mode = 'gfm'
         else if @ext == 'rst'
             @opts.mode = 'rst'
         else if @ext == 'wiki' or @ext == "mediawiki"
@@ -61,7 +63,7 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             @ext = "mediawiki"
             @opts.mode = 'mediawiki'
         else
-            throw Error('file must have extension md or html or rst or wiki or tex')
+            throw Error('file must have extension md, html, rmd, rst, tex, or wiki')
 
         @disable_preview = @local_storage("disable_preview")
         if not @disable_preview? and @opts.mode == 'htmlmixed'
@@ -426,6 +428,12 @@ class exports.HTML_MD_Editor extends editor.FileEditor
         source = @source_editor._get()
         m = require('../markdown').markdown_to_html(source)
         cb(undefined, m.s)
+
+    rmd_to_html: (cb) =>
+        @to_html_via_exec
+            command     : "rmd2html.sh"
+            args        : [@filename]
+            cb          : cb
 
     rst_to_html: (cb) =>
         @to_html_via_exec

--- a/src/smc-webapp/editor-html-md/editor-html-md.coffee
+++ b/src/smc-webapp/editor-html-md/editor-html-md.coffee
@@ -431,7 +431,7 @@ class exports.HTML_MD_Editor extends editor.FileEditor
 
     rmd_to_html: (cb) =>
         @to_html_via_exec
-            command     : "rmd2html.py"
+            command     : "smc-rmd2html"
             args        : [@filename]
             cb          : cb
 

--- a/src/smc-webapp/editor-html-md/editor-html-md.coffee
+++ b/src/smc-webapp/editor-html-md/editor-html-md.coffee
@@ -431,7 +431,7 @@ class exports.HTML_MD_Editor extends editor.FileEditor
 
     rmd_to_html: (cb) =>
         @to_html_via_exec
-            command     : "rmd2html.sh"
+            command     : "rmd2html.py"
             args        : [@filename]
             cb          : cb
 

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -185,6 +185,12 @@ file_associations['md'] =
     opts   : {indent_unit:4, tab_size:4, mode:'gfm2'}
     name   : "markdown"
 
+file_associations['rmd'] =
+    editor : 'html-md'
+    icon   : 'fa-file-code-o'
+    opts   : {indent_unit:4, tab_size:4, mode:'gfm2'}
+    name   : "Rmd"
+
 file_associations['rst'] =
     editor : 'html-md'
     icon   : 'fa-file-code-o'

--- a/src/smc_pyutil/setup.py
+++ b/src/smc_pyutil/setup.py
@@ -77,6 +77,7 @@ setup(
             'smc-top              = smc_pyutil.smc_top:main',
             'smc-git              = smc_pyutil.smc_git:main',
             'smc-html2sagews      = smc_pyutil.html2sagews:main',
+            'smc-rmd2html         = smc_pyutil.rmd2html:main',
         ]
     },
     include_package_data = True

--- a/src/smc_pyutil/smc_pyutil/rmd2html.py
+++ b/src/smc_pyutil/smc_pyutil/rmd2html.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+# rmd2html.py - used by rmd edit mode
+
+import os, sys, subprocess, errno
+
+def rmd2html(path):
+    if not os.path.exists(path):
+        raise IOError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+
+    (root, ext) = os.path.splitext(path)
+    if ext.lower() != ".rmd":
+        raise ValueError('Rmd input file required, got {}'.format(path))
+
+    cmd = '''Rscript -e "library(knitr); knit('{}')" >/dev/null 2>/dev/null'''.format(path)
+    if subprocess.call(cmd, shell=True) == 0:
+        cmd2 = "pandoc -s {}.md -t html 2>/dev/null".format(root)
+        subprocess.call(cmd2, shell=True)
+
+def main():
+    if len(sys.argv) != 2:
+        raise ValueError('Usage: {} path/to/file.Rmd'.format(sys.argv[0]))
+
+    rmd2html(sys.argv[1])
+
+if __name__ == "__main__":
+    main()
+
+
+


### PR DESCRIPTION
Ref: #1424

Initial version, allows you to open a .Rmd file and see it recompiled in real time.

Adds `rmd2html.py` (committed in `smc_pyutil`) which must be in command path.

Features possibly to be added after this:
- view pdf
- view md
- clear knitr cache
- buttonbar
    - add `r` code chunk
    - menu of code chunk options

