### PR TITLE
rmd2html: knitr::knit writes output file to current directory

### DIFF
--- a/src/smc_pyutil/smc_pyutil/rmd2html.py
+++ b/src/smc_pyutil/smc_pyutil/rmd2html.py
@@ -12,10 +12,15 @@ def rmd2html(path):
     if ext.lower() != ".rmd":
         raise ValueError('Rmd input file required, got {}'.format(path))
 
-    cmd = '''Rscript -e "library(knitr); knit('{}')" >/dev/null 2>/dev/null'''.format(path)
+    (head,tail) = os.path.split(path)
+    if head == '':
+        head = "./"
+    cmd = '''Rscript -e "library(knitr); setwd('{}'); knit('{}')" >/dev/null 2>/dev/null'''.format(head, tail)
     if subprocess.call(cmd, shell=True) == 0:
-        cmd2 = "pandoc -s {}.md -t html 2>/dev/null".format(root)
-        subprocess.call(cmd2, shell=True)
+        cmd2 = "pandoc -s {}.md -o {}.html 2>/dev/null".format(root, root)
+        if subprocess.call(cmd2, shell=True) == 0:
+            with open("{}.html".format(root), 'r') as htmlfile:
+                print(htmlfile.read())
 
 def main():
     if len(sys.argv) != 2:


### PR DESCRIPTION
@haraldschilly please see if this fixes the problem of preview not being shown.

- fix for problem where `.md` file was written to different directory than `.Rmd` file
- save intermediate `.md` file

There may still be a problem with save button not being enabled. Workaround is that system autosaves within seconds after a change in edited text.

Ref: #1424 #1434