### PR TITLE
webapp/rmd: showing errors when back-end fails to run and switching path for subdirectories

### DIFF
--- a/src/smc-webapp/editor-html-md/editor-html-md.coffee
+++ b/src/smc-webapp/editor-html-md/editor-html-md.coffee
@@ -430,9 +430,11 @@ class exports.HTML_MD_Editor extends editor.FileEditor
         cb(undefined, m.s)
 
     rmd_to_html: (cb) =>
+        split_path = misc.path_split(@filename)
         @to_html_via_exec
             command     : "smc-rmd2html"
-            args        : [@filename]
+            args        : [split_path.tail]
+            path        : split_path.head
             cb          : cb
 
     rst_to_html: (cb) =>
@@ -451,6 +453,7 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             command     : required
             args        : required
             postprocess : undefined
+            path        : undefined  # if set, change working directory to path
             cb          : required   # cb(error, html, warnings)
         html = undefined
         warnings = undefined
@@ -462,13 +465,14 @@ class exports.HTML_MD_Editor extends editor.FileEditor
                     project_id  : @project_id
                     command     : opts.command
                     args        : opts.args
+                    path        : opts.path
                     err_on_exit : false
                     cb          : (err, output) =>
                         #console.log("salvus_client.exec ", err, output)
                         if err
                             cb(err)
                         else
-                            html = output.stdout
+                            html     = output.stdout
                             warnings = output.stderr
                             cb()
         ], (err) =>
@@ -491,7 +495,7 @@ class exports.HTML_MD_Editor extends editor.FileEditor
         t0 = misc.mswalltime()
         @_update_preview_lock = true
         #console.log("update_preview")
-        @to_html (err, source) =>
+        @to_html (err, source, warnings) =>
             @_update_preview_lock = false
             if err
                 console.log("failed to render preview: #{err}")
@@ -503,22 +507,25 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             elt.find('link').remove()
             source = elt.html()
 
-            # finally set html in the live DOM
-            @preview_content.html(source)
+            if warnings
+                @preview_content.html("<pre><code>#{warnings}</code></pre>")
+            else
+                # finally set html in the live DOM
+                @preview_content.html(source)
 
-            @localize_image_links(@preview_content)
+                @localize_image_links(@preview_content)
 
-            ## this would disable clickable links...
-            #@preview.find("a").click () =>
-            #    return false
-            # Make it so preview links can be clicked, don't close SMC page.
-            @preview_content.find("a").attr("target","_blank")
-            @preview_content.find("table").addClass('table')  # bootstrap table
+                ## this would disable clickable links...
+                #@preview.find("a").click () =>
+                #    return false
+                # Make it so preview links can be clicked, don't close SMC page.
+                @preview_content.find("a").attr("target","_blank")
+                @preview_content.find("table").addClass('table')  # bootstrap table
 
-            @preview_content.mathjax()
+                @preview_content.mathjax()
 
-            #@preview_content.find(".smc-html-cursor").scrollintoview()
-            #@preview_content.find(".smc-html-cursor").remove()
+                #@preview_content.find(".smc-html-cursor").scrollintoview()
+                #@preview_content.find(".smc-html-cursor").remove()
 
             #console.log("update_preview time=#{misc.mswalltime(t0)}ms")
             if @_update_preview_redo

--- a/src/smc_pyutil/smc_pyutil/rmd2html.py
+++ b/src/smc_pyutil/smc_pyutil/rmd2html.py
@@ -8,13 +8,17 @@ def rmd2html(path):
     if not os.path.exists(path):
         raise IOError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
-    (root, ext) = os.path.splitext(path)
+    absp = os.path.abspath(path)
+    (head,tail) = os.path.split(absp)
+    os.chdir(head)
+
+    (root, ext) = os.path.splitext(tail)
     if ext.lower() != ".rmd":
         raise ValueError('Rmd input file required, got {}'.format(path))
 
-    cmd = '''Rscript -e "library(knitr); knit('{}')" >/dev/null 2>/dev/null'''.format(path)
+    cmd = '''Rscript -e "library(knitr); knit('{}')" >/dev/null'''.format(tail)
     if subprocess.call(cmd, shell=True) == 0:
-        cmd2 = "pandoc -s {}.md -t html 2>/dev/null".format(root)
+        cmd2 = "pandoc -s {}.md -t html".format(root)
         subprocess.call(cmd2, shell=True)
 
 def main():

--- a/src/smc_pyutil/smc_pyutil/rmd2html.py
+++ b/src/smc_pyutil/smc_pyutil/rmd2html.py
@@ -3,6 +3,7 @@
 # rmd2html.py - used by rmd edit mode
 
 import os, sys, subprocess, errno
+from subprocess import PIPE
 
 def rmd2html(path):
     if not os.path.exists(path):
@@ -16,10 +17,17 @@ def rmd2html(path):
     if ext.lower() != ".rmd":
         raise ValueError('Rmd input file required, got {}'.format(path))
 
+    # knitr always writes something to stderr
+    # only pass that to outer program if there is an error
     cmd = '''Rscript -e "library(knitr); knit('{}')" >/dev/null'''.format(tail)
-    if subprocess.call(cmd, shell=True) == 0:
+    p0 = subprocess.Popen(cmd, shell=True, stderr=PIPE)
+    (stdoutdata, stderrdata) = p0.communicate()
+    if p0.returncode == 0:
         cmd2 = "pandoc -s {}.md -t html".format(root)
         subprocess.call(cmd2, shell=True)
+    else:
+        sys.stderr.write(stderrdata)
+        sys.stderr.flush()
 
 def main():
     if len(sys.argv) != 2:


### PR DESCRIPTION
@DrXyzzy  this patch does two things

1. it switches to the directory where the files is -- before `smc-rmd2html` is even called. hence, all relative files will be relative to it, etc.

2. there is a variable `warnings` collecting the `stderr` output. The only problem is, in `@to_html` this warnings variable from the callback is not used at all. Therefore, I wasn't able to see any issues but now I could.

what I don't understand is what is going on with saving the file. 