### PR TITLE
add smc-m2sagews utility

### DIFF
--- a/src/smc_pyutil/setup.py
+++ b/src/smc_pyutil/setup.py
@@ -14,7 +14,7 @@ def readme():
     with open('README.md') as f:
         return f.read()
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # This checks, if setup.py is run with 'install --user'
 # in that case we assume it is installed for development and do NOT change the python executable.
@@ -47,7 +47,7 @@ setup(
     author           = 'SageMath, Inc.',
     author_email     = 'office@sagemath.com',
     license          = 'GPLv3+',
-    packages         = ['smc_pyutil'],
+    packages         = find_packages(),
     install_requires = ['markdown2', 'psutil', 'PyYAML', 'ansi2html'],
     zip_safe         = False,
     classifiers      = [

--- a/src/smc_pyutil/setup.py
+++ b/src/smc_pyutil/setup.py
@@ -78,6 +78,7 @@ setup(
             'smc-git              = smc_pyutil.smc_git:main',
             'smc-html2sagews      = smc_pyutil.html2sagews:main',
             'smc-rmd2html         = smc_pyutil.rmd2html:main',
+            'smc-m2sagews         = smc_pyutil.m2sagews:main',
         ]
     },
     include_package_data = True

--- a/src/smc_pyutil/smc_pyutil/lib/__init__.py
+++ b/src/smc_pyutil/smc_pyutil/lib/__init__.py
@@ -1,0 +1,1 @@
+from sagews_cell import *

--- a/src/smc_pyutil/smc_pyutil/lib/sagews_cell.py
+++ b/src/smc_pyutil/smc_pyutil/lib/sagews_cell.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2017, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+"""
+This script converts a .m GNU Octave file to an SMC sagews file.
+It relies on the sagews built-in mode `%octave` to instantiate a communication bridge
+to the octave Jupyter kernel.
+
+Authors:
+* Harald Schilly <hsy@sagemath.com>, started June 2016
+"""
+
+from __future__ import print_function
+import json
+from ansi2html import Ansi2HTMLConverter
+
+from smc_pyutil.sws2sagews import MARKERS, uuid
+
+class SagewsCell(object):
+
+    '''
+    Create unicode string corresponding to cell in a sage worksheet, including input/output
+    marker and uuid.
+    '''
+
+    def __init__(self, input='', outputs=None, md=None):
+        '''
+        Either specify `md` as markdown text, which is used for the text boxes in ipynb,
+        or specify `outputs` as the list of output data dictionaries from ipynb (format version 4)
+        '''
+        if outputs is not None and md is not None:
+            raise ArgumentError('Either specify md or outputs -- not both!')
+        # inline: only the essential html, no header with styling, etc.
+        # linkify: detects URLs
+        self._ansi2htmlconv = Ansi2HTMLConverter(inline=True, linkify=True)
+        # input data
+        self.input = input or ''
+        # cell states data
+        self.md = md or ''
+        self.html = ''
+        self.output = ''
+        self.ascii = ''
+        self.error = ''
+        self.stdout = ''
+        # process outputs list
+        if outputs is not None:
+            self.process_outputs(outputs)
+
+    def ansi2htmlconv(self, ansi):
+        '''
+        Sometimes, ipynb contains ansi strings with control characters for colors.
+        This little helper converts this to fixed-width formatted html with coloring.
+        '''
+        # `full = False` or else cell output is huge
+        html = self._ansi2htmlconv.convert(ansi, full=False)
+        return '<pre><span style="font-family:monospace;">%s</span></pre>' % html
+
+    def process_outputs(self, outputs):
+        """
+        Each cell has one or more outputs of different types.
+        They are collected by type and transformed later.
+        """
+        stdout = []
+        html = []
+        # ascii: for actual html content, that has been converted from ansi-encoded ascii
+        ascii = []
+        # errors are similar to ascii content
+        errors = []
+
+        for output in outputs:
+            ot = output['output_type']
+            if ot == 'stream':
+                ascii.append(self.ansi2htmlconv(output['text']))
+
+            elif ot in ['display_data', 'execute_result']:
+                data = output['data']
+                if 'text/html' in data:
+                    html.append(data['text/html'])
+                if 'text/latex' in data:
+                    html.append(data['text/latex'])
+                if 'text/plain' in data:
+                    stdout.append(data['text/plain'])
+                # print(json.dumps(data, indent=2))
+
+            elif ot in 'error':
+                if 'traceback' in output:
+                    # print(json.dumps(output['traceback'], indent=2))
+                    for tr in output['traceback']:
+                        errors.append(self.ansi2htmlconv(tr))
+
+            else:
+                print("ERROR: unknown output type '%s':\n%s" %
+                      (ot, json.dumps(output, indent=2)))
+
+        self.stdout = u'\n'.join(stdout)
+        self.html = u'<br/>'.join(html)
+        self.error = u'<br/>'.join(errors)
+        self.ascii = u'<br/>'.join(ascii)
+
+    def convert(self):
+        cell = None
+        html = self.html.strip()
+        input = self.input.strip()
+        stdout = self.stdout.strip()
+        ascii = self.ascii.strip()
+        error = self.error.strip()
+        md = self.md.strip()
+
+        def mkcell(input='', output='', type='stdout', modes=''):
+            '''
+            This is a generalized template for creating a single sagews cell.
+
+            - sagews modes:
+               * '%auto' → 'a'
+               * '%hide' → 'i'
+               * '%hideall' → 'o'
+
+            - type:
+               * err/ascii: html formatted error or ascii/ansi content
+               * stdout: plain text
+               * html/md: explicit input of html code or md, as display_data
+            '''
+            cell = MARKERS['cell'] + uuid() + modes + MARKERS['cell'] + u'\n'
+            if type == 'md':
+                cell += '%%%s\n' % type
+                output = input
+            cell += input
+            # input is done, now the output part
+            if type in ['err', 'ascii']:
+                # mangle type of output to html
+                type = 'html'
+            cell += (u'\n' + MARKERS['output'] + uuid() + MARKERS['output'] +
+                     json.dumps({type: output, 'done': True}) + MARKERS['output']) + u'\n'
+            return cell
+
+        # depending on the typed arguments, construct the sagews cell
+        if html:
+            cell = mkcell(input=input, output = html, type='html', modes='')
+        elif md:
+            cell = mkcell(input=md, type = 'md', modes='i')
+        elif error:
+            cell = mkcell(input=input, output=error, type='err')
+        elif ascii:
+            cell = mkcell(input=input, output=ascii, type='ascii')
+
+        if cell is None and (input or stdout):
+            cell = mkcell(input, stdout)
+
+        return cell

--- a/src/smc_pyutil/smc_pyutil/m2sagews.py
+++ b/src/smc_pyutil/smc_pyutil/m2sagews.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+# SageMathCloud: A collaborative web-based interface to Sage, IPython, LaTeX and the Terminal.
+#
+#    Copyright (C) 2017, SageMath, Inc.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+"""
+This script converts a .m GNU Octave file to an SMC sagews file.
+It relies on the sagews built-in mode `%octave` to instantiate a communication bridge
+to the octave Jupyter kernel.
+
+Authors:
+
+* Hal Snyder <hsnyder@sagemath.com>, started January 2017
+* Mostly copied from ipynb2sagews.py, by Harald Schilly <hsy@sagemath.com>, started June 2016
+"""
+
+from __future__ import print_function
+import sys
+import os
+import codecs
+import textwrap
+import json
+# reading the ipynb via http://nbformat.readthedocs.io/en/latest/api.html
+
+from sws2sagews import MARKERS, uuid
+
+class MCell(object):
+
+    '''
+    Create a single suitable sagews cell representation,
+    that is then inserted into the worksheet.
+
+    see http://nbformat.readthedocs.io/en/latest/format_description.html
+    '''
+
+    def __init__(self, input='', outputs=None, md=None):
+        '''
+        Either specify `md` as markdown text, which is used for the text boxes in ipynb,
+        or specify `outputs` as the list of output data dictionaries from ipynb (format version 4)
+        '''
+        if outputs is not None and md is not None:
+            raise ArgumentError('Either specify md or outputs -- not both!')
+        # inline: only the essential html, no header with styling, etc.
+        # linkify: detects URLs
+        # input data
+        self.input = input or ''
+        # cell states data
+        self.md = md or ''
+        self.html = ''
+        self.output = ''
+        self.ascii = ''
+        self.error = ''
+        self.stdout = ''
+        # process outputs list
+        if outputs is not None:
+            self.process_outputs(outputs)
+
+    def process_outputs(self, outputs):
+        """
+        Each cell has one or more outputs of different types.
+        They are collected by type and transformed later.
+        """
+        stdout = []
+        html = []
+        # ascii: for actual html content, that has been converted from ansi-encoded ascii
+        ascii = []
+        # errors are similar to ascii content
+        errors = []
+
+        self.stdout = u'\n'.join(stdout)
+        self.html = u'<br/>'.join(html)
+        self.error = u'<br/>'.join(errors)
+        self.ascii = u'<br/>'.join(ascii)
+
+    def convert(self):
+        cell = None
+        html = self.html.strip()
+        input = self.input.strip()
+        stdout = self.stdout.strip()
+        ascii = self.ascii.strip()
+        error = self.error.strip()
+        md = self.md.strip()
+
+        def mkcell(input='', output='', type='stdout', modes=''):
+            '''
+            This is a generalized template for creating a single sagews cell.
+
+            - sagews modes:
+               * '%auto' → 'a'
+               * '%hide' → 'i'
+               * '%hideall' → 'o'
+
+            - type:
+               * err/ascii: html formatted error or ascii/ansi content
+               * stdout: plain text
+               * html/md: explicit input of html code or md, as display_data
+            '''
+            cell = MARKERS['cell'] + uuid() + modes + MARKERS['cell'] + u'\n'
+            if type == 'md':
+                cell += '%%%s\n' % type
+                output = input
+            cell += input
+            # input is done, now the output part
+            if type in ['err', 'ascii']:
+                # mangle type of output to html
+                type = 'html'
+            cell += (u'\n' + MARKERS['output'] + uuid() + MARKERS['output'] +
+                     json.dumps({type: output, 'done': True}) + MARKERS['output']) + u'\n'
+            return cell
+
+        # depending on the typed arguments, construct the sagews cell
+        if html:
+            cell = mkcell(input=input, output = html, type='html', modes='')
+        elif md:
+            cell = mkcell(input=md, type = 'md', modes='i')
+        elif error:
+            cell = mkcell(input=input, output=error, type='err')
+        elif ascii:
+            cell = mkcell(input=input, output=ascii, type='ascii')
+
+        if cell is None and (input or stdout):
+            cell = mkcell(input, stdout)
+
+        return cell
+
+
+class M2SageWS(object):
+
+    def __init__(self, filename, overwrite=True):
+        """
+        Convert a GNU Octave .m file to a SageMathCloud .sagews file.
+
+        INPUT:
+        - ``filename`` -- the name of an m file, say foo.m
+
+        OUTPUT:
+        - creates a file foo.sagews if it doesn't already exist
+        """
+        self.infile = filename
+        base = os.path.splitext(filename)[0]
+        self.outfile = base + '.sagews'
+        if not overwrite and os.path.exists(self.outfile):
+            raise Exception(
+                "%s: Warning --SageMathCloud worksheet '%s' already exists.  Not overwriting.\n" % (sys.argv[0], self.outfile))
+
+        self.m = None  # holds the notebook data
+        self.output = None  # use self.write([line]) to write to output
+
+    def convert(self):
+        """
+        Main routine
+        """
+        self.read()
+        self.open()
+        self.kernel()
+        self.body()
+
+    def read(self):
+        """
+        Reads the m file
+        """
+        with open(self.infile, 'r') as inf:
+            self.m = inf.read()
+
+    def write(self, line):
+        if line is not None:
+            self.output.send(line)
+
+    def open(self):
+        sys.stdout.write("%s: Creating SageMathCloud worksheet '%s'\n" %
+                         (sys.argv[0], self.outfile))
+        sys.stdout.flush()
+
+        def output():
+            with codecs.open(self.outfile, 'w', 'utf8') as fout:
+                while True:
+                    cell = yield
+                    if cell is None:
+                        break
+                    fout.write(cell)
+        self.output = output()
+        self.output.next()
+
+    def kernel(self):
+        """
+        The first cell contains a small info text and sets the global octave mode.
+        """
+        cell = '''\
+        %auto
+        # This cell automatically evaluates on startup -- or run it manually if it didn't evaluate.
+        # Here, it starts the Jupyter octave kernel and sets it as the default mode for this worksheet.
+        %default_mode octave'''
+        self.write(MCell(input=textwrap.dedent(cell)).convert())
+
+    def body(self):
+        """
+        Convert input to body of the sagews document.
+        """
+        fhead = "# {}\n".format(self.infile)
+        self.write(MCell(input=fhead+self.m).convert())
+
+
+def main():
+    if len(sys.argv) == 1:
+        sys.stderr.write("""
+Convert a GNU Octave .m file to a SageMathCloud .sagews file.
+
+    Usage: %s path/to/filename.m [path/to/filename2.m ...]
+
+Creates corresponding file path/to/filename.sagews, if it doesn't exist. Sets
+default_mode to %octave. Places the .m file in a single sagews cell with
+file name in a comment at the start.
+""" % sys.argv[0])
+        sys.exit(1)
+
+    for path in sys.argv[1:]:
+        M2SageWS(path).convert()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Patterned after `smc-ipynb2sagews`, this PR adds a utility to take one or more `.m` files on the command line and make a `.sagews` file for each one, with a header cell setting the default mode and a single body cell containing the file contents.

Input file foo.m:
```
x = eye(5)
```

After running `smc-m2sagews foo.m`, get output file `foo.sagews`:
```
%auto
# This cell automatically evaluates on startup -- or run it manually if it didn't evaluate.
# Here, it starts the Jupyter octave kernel and sets it as the default mode for this worksheet.
%default_mode octave
--- 
# foo.m
x = eye(5)
```