### PR TITLE
Make file creation errors show again

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1828,6 +1828,7 @@ exports.ProjectFiles = rclass ({name}) ->
             error               : rtypes.string
             checked_files       : rtypes.immutable
             selected_file_index : rtypes.number
+            file_creation_error : rtypes.string
             displayed_listing   : rtypes.object
             show_upload         : rtypes.bool
             new_name            : rtypes.string


### PR DESCRIPTION
Fixes a bug where `file_creation_error` wasn't hooked up to the store.
**Edit**: Fixes #1481

Should look like this.
![error](https://cloud.githubusercontent.com/assets/618575/21826980/832e69be-d73e-11e6-826a-ca7a7430f687.png)

Test:
1. Go to file page
2. Make sure the search bar is *empty*
2. Click the down arrow of `Create`
3. Click on one of the file types.
4. You should see a notice.

This is currently broken on live. Who knows how long it's been broken for.
