### PR TITLE
For #1499: add read up to status to chats

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1898,3 +1898,17 @@ exports.bind_objects = (scope, arr_objects) ->
                 return bound_func
             else
                 return val
+
+# Provide the index that a value would be inserted
+# into an array where the val is between the number before
+# and after it
+exports.array_bisect = (arr, val) ->
+    idx = undefined
+    if arr.length == 0
+        return 0
+    idx = 0
+    while idx < arr.length
+        if val < arr[idx]
+            return idx
+        idx++
+    idx

--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1899,16 +1899,17 @@ exports.bind_objects = (scope, arr_objects) ->
             else
                 return val
 
-# Provide the index that a value would be inserted
-# into an array where the val is between the number before
-# and after it
-exports.array_bisect = (arr, val) ->
+# Assuming a sorted array of numbers return the index
+# where val is between the number in that index and
+# the number after it. Return the last index
+# if val is greater than the largest number in the array
+exports.find_smaller_number = (arr, val) ->
     idx = undefined
     if arr.length == 0
-        return 0
+        return -1
     idx = 0
     while idx < arr.length
         if val < arr[idx]
-            return idx
+            return idx - 1
         idx++
-    idx
+    idx - 1

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1389,3 +1389,8 @@ describe 'bind_objects', ->
 
         expect(b_obj1.func()).toEqual("cake")
         expect(b_obj1.val).toEqual("lies")
+
+describe 'array bisect function', ->
+    array_bisect = misc.array_bisect
+    it 'returns insertion index of 3 for a value of 11 for array of [0,3,5,15,30,90]', ->
+        array_bisect([0,3,5,15,30,90], 11).should.eql 3

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1390,7 +1390,11 @@ describe 'bind_objects', ->
         expect(b_obj1.func()).toEqual("cake")
         expect(b_obj1.val).toEqual("lies")
 
-describe 'array bisect function', ->
-    array_bisect = misc.array_bisect
-    it 'returns insertion index of 3 for a value of 11 for array of [0,3,5,15,30,90]', ->
-        array_bisect([0,3,5,15,30,90], 11).should.eql 3
+describe 'find smaller number function', ->
+    find_smaller_number = misc.find_smaller_number
+    it 'returns index of 2 for a value of 11 for array of [0,3,5,15,30,90]', ->
+        find_smaller_number([0,3,5,15,30,90], 11).should.eql 3
+    it 'returns index of -1 for a value of 3 for array of [5,10,15]', ->
+        find_smaller_number([5,10,15], 3).should.eql -1
+    it 'returns index of -1 for a value of 9 for array of []', ->
+        find_smaller_number([], 9).should.eql -1

--- a/src/smc-webapp/other-users.cjsx
+++ b/src/smc-webapp/other-users.cjsx
@@ -60,6 +60,7 @@ exports.Avatar = Avatar = rclass
         account_id : rtypes.string.isRequired
         size       : rtypes.number.isRequired
         max_age_s  : rtypes.number.isRequired
+        tooltip    : rtypes.string   # if given, showing custom tooltip string
         project_id : rtypes.string   # if given, showing avatar info for a project (or specific file)
         path       : rtypes.string   # if given, showing avatar for a specific file
         activity   : rtypes.object   # if given; is most recent activity -- {project_id:?, path:?, last_used:?} object;
@@ -125,17 +126,20 @@ exports.Avatar = Avatar = rclass
             return undefined
 
     render_tooltip_content: ->
-        name = @get_name()
-        if not @props.activity?
-            return <span>{name}</span>
-        switch @viewing_what()
-            when 'projects'
-                {ProjectTitle} = require('./projects')  # MUST be imported here.
-                <span>{name} last seen at <ProjectTitle project_id={@props.activity.project_id} /></span>
-            when 'project'
-                <span>{name} last seen at {@props.activity.path}</span>
-            when 'file'
-                <span>{name} {@render_line()}</span>
+        if @props.tooltip
+            <span>{@props.tooltip}</span>
+        else
+            name = @get_name()
+            if not @props.activity?
+                return <span>{name}</span>
+            switch @viewing_what()
+                when 'projects'
+                    {ProjectTitle} = require('./projects')  # MUST be imported here.
+                    <span>{name} last seen at <ProjectTitle project_id={@props.activity.project_id} /></span>
+                when 'project'
+                    <span>{name} last seen at {@props.activity.path}</span>
+                when 'file'
+                    <span>{name} {@render_line()}</span>
 
     render_tooltip: ->
         <Tooltip id={@props.account_id}>

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1792,9 +1792,10 @@ ProjectFilesNew = rclass
 
     file_dropdown_item: (i, ext) ->
         data = file_associations[ext]
-        <MenuItem eventKey=i key={i} onClick={=>@on_menu_item_clicked(ext)}>
-            <Icon name={data.icon.substring(3)} /> <span style={textTransform:'capitalize'}>{data.name} </span> <span style={color:'#666'}>(.{ext})</span>
-        </MenuItem>
+        if data
+            <MenuItem eventKey=i key={i} onClick={=>@on_menu_item_clicked(ext)}>
+                <Icon name={data.icon.substring(3)} /> <span style={textTransform:'capitalize'}>{data.name} </span> <span style={color:'#666'}>(.{ext})</span>
+            </MenuItem>
 
     on_menu_item_clicked: (ext) ->
         if @props.file_search.length == 0

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -126,9 +126,10 @@ NewFileDropdown = rclass
 
     file_dropdown_item: (i, ext) ->
         data = file_associations[ext]
-        <MenuItem eventKey=i key={i} onSelect={=>@props.create_file(ext)}>
-            <Icon name={data.icon.substring(3)} /> <span style={textTransform:'capitalize'}>{data.name} </span> <span style={color:'#666'}>(.{ext})</span>
-        </MenuItem>
+        if data
+            <MenuItem eventKey=i key={i} onSelect={=>@props.create_file(ext)}>
+                <Icon name={data.icon.substring(3)} /> <span style={textTransform:'capitalize'}>{data.name} </span> <span style={color:'#666'}>(.{ext})</span>
+            </MenuItem>
 
     render: ->
         <SplitButton id='new_file_dropdown'  title={@file_dropdown_icon()} onClick={=>@props.create_file()}>

--- a/src/smc-webapp/smc_chat.cjsx
+++ b/src/smc-webapp/smc_chat.cjsx
@@ -504,9 +504,9 @@ ChatLog = rclass
                 collaborators = Object.keys(redux.getStore("projects").get_project(@props.project_id).users).filter (x) -> x isnt account_id and x isnt message.get('sender_id')
                 read_by_all_collaborators = diffArray(user_ids_for_this_index, collaborators).length == 0 and collaborators.length > 1
                 if read_by_all_collaborators
-                    v.push <div key={date+'read_status'} className="small" style={color: 'rgb(136, 136, 136)'}>Read by all collaborators</div>
+                    v.push <div key={date+'read_status'} className="small" style={textAlign: 'right', color: 'rgb(136, 136, 136)'}>Read by all collaborators</div>
                 else
-                    v.push <div key={date+'read_status'}>{@render_read_avatars(user_ids_for_this_index)}</div>
+                    v.push <div key={date+'read_status'} style={textAlign: 'right'}>{@render_read_avatars(user_ids_for_this_index)}</div>
 
         return v
 


### PR DESCRIPTION
To test: open several chrome user sessions, log into same project with different smc users, and type messages and trigger mark_read. You should see Avatars if < all project collaborators read message or only two collaborators or collaborators have different read up tos and "All collaborators read" otherwise. 

A sender's Avatar does not show if they've only read up to their last message.

![image](https://cloud.githubusercontent.com/assets/12617436/22173151/d6fe9978-df6e-11e6-852f-6d8a350394d7.png)

![image](https://cloud.githubusercontent.com/assets/12617436/22173166/2bf75974-df6f-11e6-9ec2-77fb7ce75ca1.png)



