### PR TITLE
webapp/latex: drag preview with mouse, renaming output to pages

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -2342,8 +2342,8 @@ patchSynctex(\"#{@filename_tex}\");' | R --no-save"
 
     trash_aux_files: (cb) =>
         log = ''
-        EXT = ['aux', 'log', 'bbl', 'synctex.gz', 'sagetex.py', 'sagetex.sage', 'sagetex.sage.py', 'sagetex.scmd', 'sagetex.sout']
-        EXT = (E + '.' for E in EXT)
+        EXT = ['aux', 'log', 'bbl', 'fls', 'synctex.gz', 'sagetex.py', 'sagetex.sage', 'sagetex.sage.py', 'sagetex.scmd', 'sagetex.sout']
+        EXT = ('.' + E for E in EXT)
         EXT.push('-concordance.tex')
         async.series([
             (cb) =>
@@ -2357,9 +2357,11 @@ patchSynctex(\"#{@filename_tex}\");' | R --no-save"
             (cb) =>
                 # this in particular gets rid of the sagetex files
                 files = (@base_filename + ext for ext in EXT)
+                # -f: don't complain when it doesn't exist
+                # --: then it works with filenames starting with a "-"
                 @_exec
                     command : "rm"
-                    args    : ['-v'].concat(files)
+                    args    : ['-v', '-f', '--'].concat(files)
                     cb      : (err, output) ->
                         log += output.stdout + '\n\n' + output.stderr + '\n\n'
                         cb(err)

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -2556,10 +2556,12 @@ class PDF_Preview extends FileEditor
 
         @page.on 'mousedown', (e) =>
             e.preventDefault()
+            # weird next line removes the focus from the codemirror textarea
+            # otherwise, space-key and others have no effect on scrolling
+            document.activeElement.blur()
             @_dragpos =
                 left : e.clientX
                 top  : e.clientY
-            @page.css('cursor', 'move')
             return false
 
         @page.on 'mouseup', (e) =>
@@ -2577,6 +2579,7 @@ class PDF_Preview extends FileEditor
             if e.which != 1
                 reset()
                 return
+            @page.css('cursor', 'move')
             delta =
                 left : e.clientX - @_dragpos.left
                 top  : e.clientY - @_dragpos.top

--- a/src/smc-webapp/editor.html
+++ b/src/smc-webapp/editor.html
@@ -345,7 +345,7 @@ Editor for files in a project
             </span>
             <span class="btn-group pull-right">
                 <a href="#toggle-preview" class="btn btn-sm btn-default" data-toggle="tooltip" data-placement="bottom" title="If enabled, the LaTeX file is compiled and a preview is rendered.">
-                    <i class="fa fa-check-square-o"></i> Preview
+                    <i class="fa fa-check-square-o"></i> Build preview
                 </a>
             </span>
         </div>

--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -169,7 +169,7 @@ class exports.LatexEditor extends editor.FileEditor
         # This synchronizes the editor and png preview -- it's kind of disturbing.
         # If people request it, make it a non-default option...
         ###
-            @preview.output.on 'scroll', @_passive_inverse_search
+            @preview.page.on 'scroll', @_passive_inverse_search
             cm0 = @latex_editor.codemirror
             cm1 = @latex_editor.codemirror1
             cm0.on 'cursorActivity', @_passive_forward_search
@@ -1011,9 +1011,9 @@ class exports.LatexEditor extends editor.FileEditor
         if not elt?
             opts.cb?("Preview not yet loaded.")
             return
-        output = @preview.output
+        page   = @preview.page
         nH     = elt.find("img")[0].naturalHeight
-        y      = (output.height()/2 + output.offset().top - elt.offset().top) * nH / elt.height()
+        y      = (page.height()/2 + page.offset().top - elt.offset().top) * nH / elt.height()
         @_inverse_search({n:number, x:0, y:y, resolution:@preview.pdflatex.page(number).resolution, cb:opts.cb})
 
     forward_search: (opts={}) =>

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -45,7 +45,7 @@ masked_file_exts =
     'py'   : ['pyc']
     'java' : ['class']
     'cs'   : ['exe']
-    'tex'  : 'aux bbl blg fdb_latexmk glo idx ilg ind lof log nav out snm synctex.gz toc xyc'.split(' ')
+    'tex'  : 'aux bbl blg fdb_latexmk fls glo idx ilg ind lof log nav out snm synctex.gz toc xyc'.split(' ')
 
 BAD_FILENAME_CHARACTERS       = '\\'
 BAD_LATEX_FILENAME_CHARACTERS = '\'"()"~%'


### PR DESCRIPTION
see issue #19

testing:

* click and drag in a latex preview, double click should still do the inverse search.
* make sure it doesn't behave strangely when going outside the viewport or outside the browser window (i.e. it might get stuck in the mouse-down state, etc.)
* it even works on my laptop's touch screen, but I haven't tested it with an actual tablet