### PR TITLE
Save Scroll State on Courses

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1733,8 +1733,10 @@ exports.path_to_tab = (name) ->
     "editor-#{name}"
 
 # assumes a valid editor tab name...
+# If invalid or undefined, returns undefined
 exports.tab_to_path = (name) ->
-    name.substring(7)
+    if name? and name.substring(0, 7) == "editor-"
+        name.substring(7)
 
 # suggest a new filename when duplicating it
 # 1. strip extension, split at '_' or '-' if it exists

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1273,6 +1273,18 @@ describe 'change_filename_extension', ->
     it "deals with missing extensions", ->
         cfe('filename', 'tex').should.be.exactly 'filename.tex'
 
+describe 'path_to_tab', ->
+    it "appends editor- to the front of the string", ->
+        misc.path_to_tab('str').should.be.exactly 'editor-str'
+
+describe 'tab_to_path', ->
+    it "returns undefined if given undefined", ->
+        should(misc.tab_to_path()).be.undefined()
+    it "returns undefined if given a non-editor name", ->
+        should(misc.tab_to_path("non-editor")).be.undefined()
+    it "returns the string truncating editor-", ->
+        misc.tab_to_path("editor-path/name.thing").should.be.exactly "path/name.thing"
+
 describe 'suggest_duplicate_filename', ->
     dup = misc.suggest_duplicate_filename
     it "works with numbers", ->

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -258,6 +258,18 @@ ProjectMainContent = rclass
         open_files      : rtypes.object
         active_tab_name : rtypes.string
         group           : rtypes.string
+        save_scroll     : rtypes.func
+
+    componentDidUpdate: ->
+        path         = misc.tab_to_path(@props.active_tab_name)
+        saved_scroll = @props.open_files.getIn([path, 'component'])?.scroll_position
+        if saved_scroll?
+            @refs.editor_container.scrollTop = saved_scroll
+
+    componentWillUpdate: ->
+        if @refs.editor_container? and @props.save_scroll?
+            val = @refs.editor_container.scrollTop
+            @props.save_scroll(val)
 
     render_editor: (path) ->
         {Editor, redux_name} = @props.open_files.getIn([path, 'component']) ? {}
@@ -266,7 +278,7 @@ ProjectMainContent = rclass
         if not Editor?
             <Loading />
         else
-            <div style={height:'100%', display:'flex', flexDirection:'column', overflowX:'hidden'}>
+            <div ref='editor_container' style={height:'100%', display:'flex', flexDirection:'column', overflowX:'hidden'}>
                 <Editor
                     name         = {redux_name}
                     path         = {path}
@@ -490,8 +502,8 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
     render : ->
         if not @props.open_files_order?
             return <Loading />
-
-        group     = @props.get_my_group(@props.project_id)
+        group = @props.get_my_group(@props.project_id)
+        path = misc.tab_to_path(@props.active_project_tab)
 
         <div className='container-content' style={display: 'flex', flexDirection: 'column', flex: 1}>
             <FreeProjectWarning project_id={@props.project_id} name={name} />
@@ -502,6 +514,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
                 active_tab_name = {@props.active_project_tab}
                 group           = {group}
                 open_files      = {@props.open_files}
+                save_scroll     = {@actions(name).get_scroll_saver_for(path)}
             />
         </div>
 

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -260,13 +260,25 @@ ProjectMainContent = rclass
         group           : rtypes.string
         save_scroll     : rtypes.func
 
+    componentDidMount: ->
+        @restore_scroll_position()
+
+    componentWillUnmount: ->
+        @save_scroll_position()
+
     componentDidUpdate: ->
+        @restore_scroll_position()
+
+    componentWillUpdate: ->
+        @save_scroll_position()
+
+    restore_scroll_position: ->
         path         = misc.tab_to_path(@props.active_tab_name)
         saved_scroll = @props.open_files.getIn([path, 'component'])?.scroll_position
         if saved_scroll?
             @refs.editor_container.scrollTop = saved_scroll
 
-    componentWillUpdate: ->
+    save_scroll_position: ->
         if @refs.editor_container? and @props.save_scroll?
             val = @refs.editor_container.scrollTop
             @props.save_scroll(val)

--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -276,11 +276,11 @@ ProjectContentViewer = rclass
     restore_scroll_position: ->
         saved_scroll = @props.opened_file?.get('component')?.scroll_position
         if saved_scroll?
-            @refs.editor_container.scrollTop = saved_scroll
+            @refs.editor_inner_container.scrollTop = saved_scroll
 
     save_scroll_position: ->
-        if @refs.editor_container? and @props.save_scroll?
-            val = @refs.editor_container.scrollTop
+        if @refs.editor_inner_container? and @props.save_scroll?
+            val = @refs.editor_inner_container.scrollTop
             @props.save_scroll(val)
 
     render_editor: (path) ->
@@ -290,7 +290,7 @@ ProjectContentViewer = rclass
         if not Editor?
             <Loading />
         else
-            <div ref='editor_container' style={height:'100%', display:'flex', flexDirection:'column', overflowX:'hidden'}>
+            <div ref='editor_inner_container' style={height:'100%', display:'flex', flexDirection:'column', overflowX:'hidden'}>
                 <Editor
                     name         = {redux_name}
                     path         = {path}

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -390,6 +390,17 @@ class ProjectActions extends Actions
                             @set_active_tab(misc.path_to_tab(opts.path))
         return
 
+    get_scroll_saver_for: (path) =>
+        if path?
+            return (scroll_position) =>
+                store = @get_store()
+                # Ensure prerequisite things exist
+                if not store?.open_files?.getIn([path, 'component'])?
+                    return
+                # WARNING: Saving scroll position does NOT trigger a rerender. This is intentional.
+                info = store.open_files.getIn([path, 'component'])
+                info.scroll_position = scroll_position
+
     # If the given path is open, and editor supports going to line, moves to the given line.
     # Otherwise, does nothing.
     goto_line: (path, line) =>


### PR DESCRIPTION
Fixes #1561. 

Saves scroll position for any editor that doesn't maintain internal scroll state.
Implements tests for `tab_to_path` and `path_to_tab`

Testing:
1. Create a course
2. Add some assignments
3. Toggle open some assignments to produce a scroll bar
4. Open an assignment folder.
5. Return to the course to find yourself in the same position
6. Open any other page/tab in SMC and return to the course.

Do the same for students but this time open the student project.
Do the above steps again but with chat open