### PR TITLE
Add Student Sorting to Courses

### DIFF
--- a/src/smc-webapp/course/common.cjsx
+++ b/src/smc-webapp/course/common.cjsx
@@ -540,7 +540,7 @@ exports.FoldersToolbar = rclass
         @setState(add_search_results:immutable.List([]))
 
     render: ->
-        <Row>
+        <Row style={marginBottom:'-15px'}>
             <Col md=3>
                 <SearchInput
                     placeholder   = {"Find #{@props.plural_item_name}..."}

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -417,7 +417,7 @@ init_redux = (course_filename, redux, course_project_id) ->
                                     set   : {account_id: x.account_id}
                                     where : {table: 'students', student_id: v[x.email_address]}
 
-        # columns: first_name ,last_name, email, last_active
+        # columns: first_name ,last_name, email, last_active, hosting
         # Toggles ascending/decending order
         set_active_student_sort: (column_name) =>
             store = get_store()

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -417,6 +417,10 @@ init_redux = (course_filename, redux, course_project_id) ->
                                     set   : {account_id: x.account_id}
                                     where : {table: 'students', student_id: v[x.email_address]}
 
+        set_active_student_sort: (column_name) =>
+            is_descending = not get_store().getIn(['active_student_sort', 'is_descending'])
+            @setState(active_student_sort : {column_name, is_descending})
+
         # Student projects
 
         # Create a single student project.

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -2044,23 +2044,20 @@ CourseEditor = rclass ({name}) ->
             {@render_save_timetravel()}
             <Tabs id='course-tabs' animation={false} activeKey={@props.tab} onSelect={(key)=>@props.redux?.getActions(@props.name).set_tab(key)}>
                 <Tab eventKey={'students'} title={<StudentsPanel.Header n={@num_students()} />}>
-                    <div style={marginTop:'8px'}></div>
                     {@render_students()}
                 </Tab>
                 <Tab eventKey={'assignments'} title={<AssignmentsPanel.Header n={@num_assignments()}/>}>
-                    <div style={marginTop:'8px'}></div>
                     {@render_assignments()}
                 </Tab>
                 <Tab eventKey={'handouts'} title={<HandoutsPanel.Header n={@num_handouts()}/>}>
-                    <div style={marginTop:'8px'}></div>
                     {@render_handouts()}
                 </Tab>
                 <Tab eventKey={'settings'} title={<SettingsPanel.Header />}>
-                    <div style={marginTop:'8px'}></div>
+                    <div style={marginTop:'1em'}></div>
                     {@render_settings()}
                 </Tab>
                 <Tab eventKey={'shared_project'} title={<SharedProjectPanel.Header project_exists={!!@props.settings?.get('shared_project_id')}/>}>
-                    <div style={marginTop:'8px'}></div>
+                    <div style={marginTop:'1em'}></div>
                     {@render_shared_project()}
                 </Tab>
             </Tabs>

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -420,7 +420,12 @@ init_redux = (course_filename, redux, course_project_id) ->
         # columns: first_name ,last_name, email, last_active
         # Toggles ascending/decending order
         set_active_student_sort: (column_name) =>
-            is_descending = not get_store().getIn(['active_student_sort', 'is_descending'])
+            store = get_store()
+            current_column = store.getIn(['active_student_sort', 'column_name'])
+            if current_column == column_name
+                is_descending = not get_store().getIn(['active_student_sort', 'is_descending'])
+            else
+                is_descending = false
             @setState(active_student_sort : {column_name, is_descending})
 
         # Student projects

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -417,6 +417,8 @@ init_redux = (course_filename, redux, course_project_id) ->
                                     set   : {account_id: x.account_id}
                                     where : {table: 'students', student_id: v[x.email_address]}
 
+        # columns: first_name ,last_name, email, last_active
+        # Toggles ascending/decending order
         set_active_student_sort: (column_name) =>
             is_descending = not get_store().getIn(['active_student_sort', 'is_descending'])
             @setState(active_student_sort : {column_name, is_descending})

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -252,7 +252,7 @@ exports.StudentsPanel = rclass ({name}) ->
         (a,b) -> misc.cmp(a[field].toLowerCase(), b[field].toLowerCase())
 
     sort_on_numerical_field: (field) ->
-        (a,b) -> misc.cmp(a[field], b[field])
+        (a,b) -> misc.cmp(a[field] * -1, b[field] * -1)
 
     pick_sorter: (sort=@props.active_student_sort) ->
         switch sort.column_name
@@ -260,6 +260,7 @@ exports.StudentsPanel = rclass ({name}) ->
             when "first_name" then @sort_on_string_field("first_name")
             when "last_name" then @sort_on_string_field("last_name")
             when "last_active" then @sort_on_numerical_field("last_active")
+            when "hosting" then @sort_on_numerical_field("hosting")
 
     compute_student_list: ->
         # TODO: good place to cache something...
@@ -286,10 +287,14 @@ exports.StudentsPanel = rclass ({name}) ->
                 x.last_name  = user?.get('last_name') ? ''
                 if x.project_id?
                     x.last_active = @props.redux.getStore('projects').get_last_active(x.project_id)?.get(x.account_id).getTime()
+                    upgrades = @props.redux.getStore('projects').get_total_project_quotas(x.project_id)
+                    if upgrades?
+                        x.hosting = upgrades.member_host
 
             x.first_name  ?= ""
             x.last_name   ?= ""
             x.last_active ?= 0
+            x.hosting ?= false
             x.email_address ?= ""
 
         v.sort @pick_sorter()

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -207,13 +207,11 @@ exports.StudentsPanel = rclass ({name}) ->
                 msg += existing.join(', ')
                 ed = <ErrorDisplay bsStyle='info' error=msg onClose={=>@setState(existing_students:undefined)} />
         if ed?
-            <Row style={marginTop:'1em'}><Col md=5 lgOffset=7>{ed}</Col></Row>
-        else
-            <Row></Row>
+            <Row style={marginTop:'1em', marginBottom:'-10px'}><Col md=5 lgOffset=7>{ed}</Col></Row>
 
     render_header: (num_omitted) ->
         <div>
-            <Row>
+            <Row style={marginBottom:'-15px'}>
                 <Col md=3>
                     <SearchInput
                         placeholder = "Find students..."

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -12,16 +12,13 @@ misc = require('smc-util/misc')
 {ErrorDisplay, Icon, MarkdownInput, SearchInput, Space, TimeAgo, Tip} = require('../r_misc')
 {StudentAssignmentInfo, StudentAssignmentInfoHeader} = require('./common')
 
-entry_style =
-    paddingTop    : '5px'
-    paddingBottom : '5px'
-
-selected_entry_style = misc.merge
+selected_entry_style =
     border        : '1px solid #aaa'
     boxShadow     : '5px 5px 5px #999'
     borderRadius  : '3px'
-    marginBottom  : '10px',
-    entry_style
+    marginBottom  : '10px'
+    paddingBottom : '5px'
+    paddingTop    : '5px'
 
 note_style =
     borderTop  : '3px solid #aaa'
@@ -50,7 +47,7 @@ exports.StudentsPanel = rclass ({name}) ->
         assignments : rtypes.object.isRequired
 
     getDefaultProps: ->
-        column_name = "email"
+        column_name = "last_name"
         is_descending = false
         return active_student_sort : {column_name, is_descending}
 
@@ -321,50 +318,35 @@ exports.StudentsPanel = rclass ({name}) ->
 
         return {students:v, num_omitted:num_omitted, num_deleted:num_deleted}
 
+    render_sort_link: (column_name, display_name) ->
+        <a href=''
+            onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort(column_name)}>
+            {display_name}
+            <Space/>
+            {<Icon style={marginRight:'10px'}
+                name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}
+            /> if @props.active_student_sort.column_name == column_name}
+        </a>
+
     render_student_table_header: ->
-        <Row>
+        # HACK: -10px margin gets around ReactBootstrap's incomplete access to styling
+        <Row style={marginTop:'-10px', marginBottom:'3px'}>
             <Col md=3>
-                <a href=''
-                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('first_name')}>
-                    First Name
-                    <Space/>
-                    <Icon style={marginRight:'10px'}
-                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
-                </a>
-                <a href=''
-                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('last_name')}>
-                    Last Name
-                    <Space/>
-                    <Icon style={marginRight:'10px'}
-                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
-                </a>
+                <div style={display:'inline-block', width:'50%'}>
+                    {@render_sort_link("first_name", "First Name")}
+                </div>
+                <div style={display:"inline-block"}>
+                    {@render_sort_link("last_name", "Last Name")}
+                </div>
             </Col>
             <Col md=2>
-                <a href=''
-                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('email')}>
-                    Student Email
-                    <Space/>
-                    <Icon style={marginRight:'10px'}
-                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
-                </a>
+                {@render_sort_link("email", "Student Email")}
             </Col>
-            <Col md=4 style={paddingTop:'10px'}>
-                <a href=''
-                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('last_active')}>
-                    Last Active
-                    <Space/>
-                    <Icon style={marginRight:'10px'}
-                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
-                </a>
+            <Col md=4>
+                {@render_sort_link("last_active", "Last Active")}
             </Col>
-            <Col md=3 style={paddingTop:'10px'}>
-                <a href=''
-                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('hosting')}>
-                    Hosting Type
-                    <Space/>
-                    <Icon style={marginRight:'10px'}
-                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
-                </a>
+            <Col md=3>
+                {@render_sort_link("hosting", "Hosting Type")}
             </Col>
         </Row>
 
@@ -641,7 +623,7 @@ Student = rclass
         </Panel>
 
     render: ->
-        <Row style={if @state.more then selected_entry_style else entry_style}>
+        <Row style={if @state.more then selected_entry_style}>
             <Col xs=12>
                 {@render_basic_info()}
                 {@render_more_panel() if @props.is_expanded}

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -321,6 +321,53 @@ exports.StudentsPanel = rclass ({name}) ->
 
         return {students:v, num_omitted:num_omitted, num_deleted:num_deleted}
 
+    render_student_table_header: ->
+        <Row>
+            <Col md=3>
+                <a href=''
+                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('first_name')}>
+                    First Name
+                    <Space/>
+                    <Icon style={marginRight:'10px'}
+                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
+                </a>
+                <a href=''
+                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('last_name')}>
+                    Last Name
+                    <Space/>
+                    <Icon style={marginRight:'10px'}
+                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
+                </a>
+            </Col>
+            <Col md=2>
+                <a href=''
+                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('email')}>
+                    Student Email
+                    <Space/>
+                    <Icon style={marginRight:'10px'}
+                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
+                </a>
+            </Col>
+            <Col md=4 style={paddingTop:'10px'}>
+                <a href=''
+                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('last_active')}>
+                    Last Active
+                    <Space/>
+                    <Icon style={marginRight:'10px'}
+                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
+                </a>
+            </Col>
+            <Col md=3 style={paddingTop:'10px'}>
+                <a href=''
+                    onClick={(e)=>e.preventDefault();@actions(@props.name).set_active_student_sort('hosting')}>
+                    Hosting Type
+                    <Space/>
+                    <Icon style={marginRight:'10px'}
+                        name={if @props.active_student_sort.is_descending then 'caret-up' else 'caret-down'}/>
+                </a>
+            </Col>
+        </Row>
+
     render_students: (students) ->
         for x,i in students
             <Student background={if i%2==0 then "#eee"} key={x.student_id}
@@ -348,6 +395,7 @@ exports.StudentsPanel = rclass ({name}) ->
     render: ->
         {students, num_omitted, num_deleted} = @compute_student_list()
         <Panel header={@render_header(num_omitted, num_deleted)}>
+            {@render_student_table_header()}
             {@render_students(students)}
             {@render_show_deleted(num_deleted) if num_deleted}
         </Panel>


### PR DESCRIPTION
## Fixes most of #1447  

Things **not** in this PR:
- Custom ordering
- Changing default ordering

### Adds headers to students panel columns
![adjusted](https://cloud.githubusercontent.com/assets/618575/22455397/1d9caf1c-e741-11e6-8f69-ee9b3efbd297.png)
Also adjusts some spacing across tabs.

### Spacing on the Assignments tab (Handouts is similar)
![assignments](https://cloud.githubusercontent.com/assets/618575/22455398/1d9ccad8-e741-11e6-8e46-eda6b0b25f89.png)

### Settings (and shared project) gets adjusted to match Account Settings
![settings](https://cloud.githubusercontent.com/assets/618575/22455399/1d9edf44-e741-11e6-826d-2dd2f762c3cc.png)

Account settings:
![account settings](https://cloud.githubusercontent.com/assets/618575/22455396/1d98d7a2-e741-11e6-9c15-b159be8ba6e8.png)


### Sort without spacing adjustments:
![current sort](https://cloud.githubusercontent.com/assets/618575/22455357/ce7d4252-e740-11e6-957c-87a4ca79cb70.png)


## Testing
1. Create students in a course
2. Clicking on any of the headers should sort by that column.
3. Clicking on the same header again should reverse the order.
4. Clicking on a different header should start with the arrow pointed down.
5. Any columns not being sorted by should not have any arrow next to the name
6. The arrow should initially appear next to `Last Name`
7. Arrow down should mean a -> z (caps ignored) for names and emails.
8. Arrow down for `Last Active` should mean most recent to never used
9. Arrow down for `Hosting Type` should put members before free servers.
