### PR TITLE
markdown external links

### DIFF
--- a/src/scripts/postgresql/cool-queries.md
+++ b/src/scripts/postgresql/cool-queries.md
@@ -34,6 +34,10 @@ Find active sage worksheets:
 
     select * from syncstrings where path like '%.sagews' and last_active is not null order by last_active desc limit 10;
 
+Same as above, but return URIs to the files.
+
+    select format('/projects/%s/files/%s', project_id, path) from syncstrings where path like '%.sagews' and last_active is not null order by last_active desc limit 30;
+
 Active syncstrings:
 
     select string_id, project_id, left(path,50) as path, NOW()-last_active from syncstrings where last_active is not null order by last_active desc limit 20;

--- a/src/smc-webapp/editor-html-md/editor-html-md.coffee
+++ b/src/smc-webapp/editor-html-md/editor-html-md.coffee
@@ -530,13 +530,11 @@ class exports.HTML_MD_Editor extends editor.FileEditor
                 # finally set html in the live DOM
                 @preview_content.html(source)
 
-                @localize_image_links(@preview_content)
+                @preview_content.process_smc_links(
+                    project_id  : @project_id
+                    file_path   : @file_path()
+                )
 
-                ## this would disable clickable links...
-                #@preview.find("a").click () =>
-                #    return false
-                # Make it so preview links can be clicked, don't close SMC page.
-                @preview_content.find("a").attr("target","_blank")
                 @preview_content.find("table").addClass('table')  # bootstrap table
 
                 @preview_content.mathjax()
@@ -548,18 +546,6 @@ class exports.HTML_MD_Editor extends editor.FileEditor
             if @_update_preview_redo
                 @_update_preview_redo = false
                 @update_preview()
-
-    localize_image_links: (e) =>
-        {join} = require('path')
-        # make relative links to images and objects use the raw server
-        for [tag, attr] in [['img', 'src'], ['object', 'data']]
-            for x in e.find(tag)
-                y = $(x)
-                src = y.attr(attr)
-                if not src? or src[0] == '/' or src.indexOf('://') != -1
-                    continue
-                new_src = join('/', window.smc_base_url, @project_id, 'raw', @file_path(), src)
-                y.attr(attr, new_src)
 
     init_preview_select: () =>
         @preview_content.click (evt) =>

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -156,15 +156,15 @@ $.fn.process_smc_links = (opts={}) ->
 
         # make relative links to images use the raw server
         if opts.project_id and opts.file_path?
-            a = e.find("img")
-            for x in a
-                y = $(x)
-                src = y.attr('src')
-                if src.indexOf('://') != -1
-                    continue
-                {join} = require('path')
-                new_src = join('/', window.smc_base_url, opts.project_id, 'raw', opts.file_path, src)
-                y.attr('src', new_src)
+            for [tag, attr] in [['img', 'src'], ['object', 'data']]
+                for x in e.find(tag)
+                    y = $(x)
+                    src = y.attr(attr)
+                    if src.indexOf('://') != -1
+                        continue
+                    {join} = require('path')
+                    new_src = join('/', window.smc_base_url, opts.project_id, 'raw', opts.file_path, src)
+                    y.attr(attr, new_src)
 
         return e
 


### PR DESCRIPTION
right now, in the preview of md files, relative and absolute links inside SMC open a new tab .This fixes this. It also ports the enhancements from the now removed image and object source rewriter to this plugin.

testing: check that relative urls open inside smc inside the md preview. since the jquery plugin is touched, also check that images in `%md` cells pointing relatively to smc still work.