### PR TITLE
webapp/sagews: hotfix for line breaks in stdout

### DIFF
--- a/src/smc-webapp/_editor.sass
+++ b/src/smc-webapp/_editor.sass
@@ -369,7 +369,9 @@
 .sagews-output-md
   font-family : helvetica
 
-//.sagews-output-stdout
+.sagews-output-stdout,
+.sagews-output-stderr
+  display     : block
 
 .sagews-output-stderr
   color       : red


### PR DESCRIPTION
I don't know what's happening. There has been a tiny change in the css and this patch here at least makes them blocks and hence there is a perceived line break. What was the problem (or what was fixed by the change) before? /cc @williamstein 