### PR TITLE
webapp/files: this fixes "icon undefined" errors of new file dropdown lists, in NewFileDropdown and ProjectFilesNew

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -231,7 +231,7 @@ file_associations['css'] =
 for m in ['noext-makefile', 'noext-Makefile', 'noext-GNUmakefile', 'make', 'build']
     file_associations[m] =
         editor : 'codemirror'
-        icon   : 'cogs'
+        icon   : 'fa-cogs'
         opts   : {mode:'makefile', indent_unit:4, tab_size:4, spaces_instead_of_tabs: false}
         name   : "Makefile"
 

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -356,10 +356,8 @@ initialize_new_file_type_list = () ->
 initialize_new_file_type_list()
 
 exports.file_icon_class = file_icon_class = (ext) ->
-    if (file_associations[ext]? and file_associations[ext].icon?)
-        return file_associations[ext].icon
-    else
-        return 'fa-file-o'
+    assoc = exports.file_options('x.' + ext)
+    return assoc.icon
 
 # Multiplex'd worksheet mode
 
@@ -503,6 +501,8 @@ exports.file_options = (filename, content) ->   # content may be undefined
         x = file_associations[ext]
     if not x?
         x = file_associations['']
+    if not x.icon?
+        x.icon = 'fa-file-o'
     return x
 
 SEP = "\uFE10"

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1810,7 +1810,8 @@ ProjectFilesNew = rclass
         <span><Icon name='plus-circle' /> Create</span>
 
     file_dropdown_item: (i, ext) ->
-        data = file_associations[ext]
+        {file_options} = require('./editor')
+        data = file_options('x.' + ext)
         <MenuItem eventKey=i key={i} onClick={=>@on_menu_item_clicked(ext)}>
             <Icon name={data.icon.substring(3)} /> <span style={textTransform:'capitalize'}>{data.name} </span> <span style={color:'#666'}>(.{ext})</span>
         </MenuItem>

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -125,7 +125,8 @@ NewFileDropdown = rclass
         </span>
 
     file_dropdown_item: (i, ext) ->
-        data = file_associations[ext]
+        {file_options} = require('./editor')
+        data = file_options('x.' + ext)
         <MenuItem eventKey=i key={i} onSelect={=>@props.create_file(ext)}>
             <Icon name={data.icon.substring(3)} /> <span style={textTransform:'capitalize'}>{data.name} </span> <span style={color:'#666'}>(.{ext})</span>
         </MenuItem>


### PR DESCRIPTION
That's based on these new error reports. I actually don't know how to trigger the error, which is weird. This change at least uses the functions from the editor to derive the icon and there are also small changes to make sure that there is always an icon defined.