### PR TITLE
webapp/latex: safeguarding against error f0ad8861-2387-4053-8f80-abafc4d5423c

### DIFF
--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -188,8 +188,8 @@ class exports.LatexEditor extends editor.FileEditor
                 if err
                     cb?(err)
                 else
-                    @latex_editor.codemirror.spellcheck_highlight(words)
-                    @latex_editor.codemirror1.spellcheck_highlight(words)
+                    @latex_editor.codemirror?.spellcheck_highlight(words)
+                    @latex_editor.codemirror1?.spellcheck_highlight(words)
 
     init_draggable_split: () =>
         @_split_pos = @local_storage(LSkey.split_pos)


### PR DESCRIPTION
Looks like a simple race condition in the callback. This should prevent that exception:

```
id           | f0ad8861-2387-4053-8f80-abafc4d5423c
name         | TypeError
message      | Cannot read property 'spellcheck_highlight' of undefined
comment      | 
stacktrace   | TypeError: Cannot read property 'spellcheck_highlight' of undefined                                                                                                                                                                                              

             |     at Object.preview.pdflatex.spell_check.cb (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:225:12272) 
             |     at Object.disable.e.lang._exec.cb (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:29:28685)
             |     at cb (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:173:21399) 
             |     at n.exports.Connection.t.handle_json_data (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:173:10116)
             |     at https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:172:30894
             |     at n.exports.Connection.t._handle_data (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:173:10743)
             |     at n._handle_data (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:172:30894)
             |     at Primus.<anonymous> (https://cloud.sagemath.com/static/smc-a16074d1e62237848769.js?a16074d1e62237848769:173:5913)
             |     at Primus.emit (eval at e.exports (https://cloud.sagemath.com/static/lib-a16074d1e62237848769.js?a16074d1e62237848769:1:1), <anonymous>:1:3451) 
```