### PR TITLE
Fix rare file use bug

### DIFF
--- a/src/smc-webapp/file_use.cjsx
+++ b/src/smc-webapp/file_use.cjsx
@@ -500,7 +500,7 @@ FileUseViewer = rclass
         </Button>
 
     open_selected: ->
-        open_file_use_entry(@_visible_list?[@state.cursor].toJS(), @props.redux)
+        open_file_use_entry(@_visible_list?[@state.cursor]?.toJS(), @props.redux)
 
     render_list: ->
         v = @props.file_use_list.toArray()


### PR DESCRIPTION
Per bug found by HSY webapp error reporter!

Would throw an error when someone with no file use notifications tried to submit a search inside the file use widget.