### PR TITLE
webapp/errors: "getViewport" property is undefined

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1542,6 +1542,8 @@ class CodeMirrorEditor extends FileEditor
         return @codemirror.getValue()
 
     _set: (content) =>
+        if not @codemirror?
+            return
         {from} = @codemirror.getViewport()
         @codemirror.setValue(content)
         @codemirror.scrollIntoView(from)


### PR DESCRIPTION
the no. 1 reported error is like

```
TypeError: Cannot read property 'getViewport' of undefined
             |     at n._set (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:29:9926)
             |     at n.<anonymous> (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:28:4965)
             |     at n._set (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:28:4965)
             |     at Object.cb (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:168:8473)
             |     at https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:160:15271
             |     at function.e._wrapper.e._wrapper (https://cloud.sagemath.com/static/lib-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:131:3934)
             |     at https://cloud.sagemath.com/static/lib-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:131:5448
```

since there is 2x `_set`, my assumption is that this is  `@_syncstring.wait_until_read_only_known` in syncdoc, and then after the cb and via `_set` in an editor, it ends up in `CodeMirrorEditor`'s `_set`. Maybe again, there is a more elegant fix.