### PR TITLE
webapp/errors: scroll_into_view -> offset undefined

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -2663,10 +2663,10 @@ class PDF_Preview extends FileEditor
             y              : 0          # y-coordinate on page
             highlight_line : true
         pg = @pdflatex.page(opts.n)
-        if not pg?
+        elt = @element.find(".salvus-editor-pdf-preview-output")
+        if not pg? or not elt?
             # the page has vanished in the meantime...
             return
-        elt = @element.find(".salvus-editor-pdf-preview-output")
         t = elt.offset().top
         elt.scrollTop(0)  # reset to 0 first so that pg.element.offset().top is correct below
         top = (pg.element.offset().top + opts.y) - $(window).height() / 2


### PR DESCRIPTION
Only concerns tex files, and this fix is based on exceptions like

```
stacktrace   | TypeError: Cannot read property 'offset' of undefined                                                                                                +
             |     at n.scroll_into_view (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:30:3131)                               +
             |     at n.scroll_into_view (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:28:4965)                               +
             |     at n.zoom (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:30:1896)                                           +
             |     at n.zoom (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:28:4965)                                           +
             |     at HTMLAnchorElement.<anonymous> (https://cloud.sagemath.com/static/smc-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:225:19687)                  +
             |     at HTMLAnchorElement.dispatch (https://cloud.sagemath.com/static/lib-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:18:4669)                       +
             |     at HTMLAnchorElement.g.handle (https://cloud.sagemath.com/static/lib-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:18:2696)                       +
             |     at HTMLAnchorElement.function.e._wrapper.e._wrapper (https://cloud.sagemath.com/static/lib-cd251bc36c45dc61b87c.js?cd251bc36c45dc61b87c:131:3934)

```