### PR TITLE
webapp/3d: noKeys deprecated

### DIFF
--- a/src/smc-webapp/3d.coffee
+++ b/src/smc-webapp/3d.coffee
@@ -248,7 +248,7 @@ class SalvusThreeJS
         # set up camera controls
         @controls = new THREE.OrbitControls(@camera, @renderer.domElement)
         @controls.damping = 2
-        @controls.noKeys = true
+        @controls.enableKeys = false # see https://github.com/mrdoob/three.js/blob/master/examples/js/controls/OrbitControls.js#L962
         @controls.zoomSpeed = 0.4
         if @_center?
             @controls.target = @_center


### PR DESCRIPTION
That's a trivial one, see https://github.com/mrdoob/three.js/blob/master/examples/js/controls/OrbitControls.js#L962

```
message      | THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.
comment      | 
stacktrace   | <generated>                                                                                                                                 +
             | Error                                                                                                                                       +
             |     at i (https://cloud.sagemath.com/static/lib-a16074d1e62237848769.js?a16074d1e62237848769:131:6199)                                      +
             |     at d (https://cloud.sagemath.com/static/lib-a16074d1e62237848769.js?a16074d1e62237848769:131:8765)                                      +
             |     at Object.<anonymous> (https://cloud.sagemath.com/static/lib-a16074d1e62237848769.js?a16074d1e62237848769:131:8976)                     +
             |     at Object.e.(anonymous function) [as warn] (https://cloud.sagemath.com/static/lib-a16074d1e62237848769.js?a16074d1e62237848769:131:8842)+
             |     at THREE.OrbitControls.set (eval at e.exports (https://cloud.sagemath.com/static/0-a16074d1e62237848769.js:6:114), <anonymous>:994:12)  +
             |     at e.init_orbit_controls (https://cloud.sagemath.com/static/0-a16074d1e62237848769.js:22:22694)                                         +
             |     at e.init_orbit_controls (https://cloud.sagemath.com/static/0-a16074d1e62237848769.js:22:16552)                                         +
             |     at e.init (https://cloud.sagemath.com/static/0-a16074d1e62237848769.js:22:18982)                                                        +
             |     at e.init (https://cloud.sagemath.com/static/0-a16074d1e62237848769.js:22:16552)                                                        +
             |     at Object.a [as cb] (https://cloud.sagemath.com/static/0-a16074d1e62237848769.js:23:2298)

```