### PR TITLE
webapp/latex: fixing "_smc_inline_errors" undefined

### DIFF
--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -745,7 +745,7 @@ class exports.LatexEditor extends editor.FileEditor
 
     _render_inline_error: (line, message, content, error_type) =>
         line -= 1 # to get 0-based numbering for the remaining code
-        if error_type != 'error'
+        if error_type != 'error' or not @latex_editor.codemirror?
             # only show errors, warnings and typesettings are too verbose
             return
         # at most one error widget per line ...


### PR DESCRIPTION
yet another case where codemirror is gone

```
message      | Cannot read property '_smc_inline_errors' of undefined
comment      | 
stacktrace   | TypeError: Cannot read property '_smc_inline_errors' of undefined                                                                                 +
             |     at f.exports.LatexEditor.f._render_inline_error (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:29730)+
             |     at f._render_inline_error (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:9455)                       +
             |     at f.exports.LatexEditor.f.render_error_message (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:31879)+
             |     at f.render_error_message (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:9455)                       +
             |     at f.exports.LatexEditor.f._render_error_page (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:28280)  +
             |     at https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:9455                                                +
             |     at https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:15:20743                                                +
             |     at r (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:15:24048)                                            +
             |     at o (https://cloud.sagemath.com/static/lib-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:160:30797)                                           +
             |     at a (https://cloud.sagemath.com/static/lib-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:160:30975)

```