### PR TITLE
webapp/latex: on firefox, the embedded preview is disabled

### DIFF
--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -89,7 +89,7 @@ class exports.LatexEditor extends editor.FileEditor
         @latex_editor.on 'saved', () =>
             @update_preview () =>
                 if @_current_page == 'pdf-preview'
-                    @preview_embed.update()
+                    @preview_embed?.update()
             @spell_check()
 
         @latex_editor.syncdoc.on 'connect', () =>
@@ -315,7 +315,7 @@ class exports.LatexEditor extends editor.FileEditor
         @latex_editor.remove()
         @element.remove()
         @preview.remove()
-        @preview_embed.remove()
+        @preview_embed?.remove()
 
     _init_buttons: () =>
         @element.find("a").tooltip(TOOLTIP_CONFIG)
@@ -498,7 +498,7 @@ class exports.LatexEditor extends editor.FileEditor
             if not err
                 @update_preview (force=force) =>
                     if @_current_page == 'pdf-preview'
-                        @preview_embed.update()
+                        @preview_embed?.update()
                 @spell_check()
 
     update_preview: (cb, force=false, only_compile=false) =>


### PR DESCRIPTION
on firefox, the `@preview_emebd` is disabled, because it triggers PDF downloads.

this patch takes care of that when it isn't defined

stacktrace:

```
stacktrace   | exports.LatexEditor</f.prototype.remove@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:19052                                     +
             | b/<@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:225:9453                                                                          +
             | Le/<@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:28:4963                                                                          +
             | exports.register_nonreact_editor/<.remove@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:206:29828                                   +
             | exports.remove@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:53:1296                                                                +
             | u</n.prototype.close_file@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:167:10969                                                   +
             | D/<@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:166:28262                                                                         +
             | u</n.prototype.close_tab@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:167:2663                                                     +
             | D/<@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:166:28262                                                                         +
             | u<.close_file@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:172:15400                                                               +
             | u<.render/<.onClick</<@https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:172:16362  
```