### PR TITLE
webapp/editor: Cannot read property getCursor of undefined

### DIFF
--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1827,6 +1827,8 @@ class CodeMirrorEditor extends FileEditor
 
         update_context_sensitive_bar = () =>
             cm = @focused_codemirror()
+            if not cm?
+                return
             pos = cm.getCursor()
             name = cm.getModeAt(pos).name
             #console.log("update_context_sensitive_bar, pos=#{misc.to_json(pos)}, name=#{name}")


### PR DESCRIPTION
stacktrace:

```
stacktrace   | TypeError: Cannot read property 'getCursor' of undefined                                                                           +
             |     at https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:29:16675                                 +
             |     at l (https://cloud.sagemath.com/static/smc-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:15:4341)                              +
             |     at function.e._wrapper.e._wrapper (https://cloud.sagemath.com/static/lib-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:131:3934)+
             |     at https://cloud.sagemath.com/static/lib-d3fe692e11c3c55d6e10.js?d3fe692e11c3c55d6e10:131:5448
```

is very vague. I've looked up line 29, column 16675  in the minified source:

```
[...] var t,n;return t=e.focused_codemirror(),n=t.getCursor(),ue=t.getModeAt(n).name,"xml"===ue||"stex"===ue||"markdown"===ue||"mediawiki"===ue? [...]
```
which is

```
        update_context_sensitive_bar = () =>
            cm = @focused_codemirror()
            pos = cm.getCursor()
            name = cm.getModeAt(pos).name
```

being called async from that `debounce` below.