### PR TITLE
latex error log parsing for files with spaces in their name

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -564,7 +564,7 @@ exports.define_codemirror_extensions = () ->
     startswith = misc.startswith
 
     CodeMirror.registerHelper "fold", "stex", (cm, start) ->
-        trimStart = require('lodash.trimstart')
+        trimStart = require('lodash/trimStart')
         line = trimStart(cm.getLine(start.line))
         find_close = () ->
             BEGIN = "\\begin"

--- a/src/smc-webapp/package.json
+++ b/src/smc-webapp/package.json
@@ -38,7 +38,7 @@
     "jquery-ui-touch-punch": "^0.2.3",
     "jquery.payment": "git://github.com/stripe/jquery.payment.git",
     "json-stable-stringify": "^1.0.1",
-    "lodash.trimstart": "^4.5.1",
+    "lodash": "^4.17.4",
     "marked": "^0.3.3",
     "mathjax": "^2.6.1",
     "md5": "^2.0.0",

--- a/src/webapp-lib/latex/latex-log-parser.coffee
+++ b/src/webapp-lib/latex/latex-log-parser.coffee
@@ -239,9 +239,11 @@ LatexParser = (text, options) ->
         # Our heuristic for detecting file names are rather crude
         # A file may not contain a space, or ) in it
         # To be a file path it must have at least one /
+        # hsy: slight enhancement: search until ")" or EOL, and then trim the string
         if !@currentLine.match(/^\/?([^ \)]+\/)+/)
             return false
-        endOfFilePath = @currentLine.search(RegExp(' |\\)'))
+        trimEnd = require('lodash/trimEnd')
+        endOfFilePath = trimEnd(@currentLine.search(RegExp('$|\\)')))
         path = undefined
         if endOfFilePath == -1
             path = @currentLine
@@ -249,6 +251,8 @@ LatexParser = (text, options) ->
         else
             path = @currentLine.slice(0, endOfFilePath)
             @currentLine = @currentLine.slice(endOfFilePath)
+        #if DEBUG
+        #    console.log("latex-log-parser@consumeFilePath", @currentLine, "endOfFilePath:", endOfFilePath, "-> path: '#{path}'")
         path
 
     @postProcess = (data) ->


### PR DESCRIPTION
see #1567 

test: 

1. create a faulty latex file "with spaces.tex" and check that errors reference that file fine.

2. create a `latex.tex` that references `with space.xyz` inside of it via `\input{"with space.xyz"}`. given "with space.xyz" contains an latex error,  the error message in "latex.tex" shows and references the full "with space.xyz" filename -- and clicking on the button opens the file correctly.

check: "normal" file names still work fine.