### PR TITLE
allow for blank first name or last name when deleting account

### DIFF
--- a/src/smc-webapp/r_account.cjsx
+++ b/src/smc-webapp/r_account.cjsx
@@ -495,7 +495,7 @@ AccountSettings = rclass
                         initial_click = {()=>@setState(show_delete_confirmation:true)}
                         confirm_click = {=>@actions('account').delete_account()}
                         cancel_click  = {()=>@setState(show_delete_confirmation:false)}
-                        user_name     = {@props.first_name + ' ' + @props.last_name}
+                        user_name     = {(@props.first_name + ' ' + @props.last_name).trim()}
                         show_confirmation={@state.show_delete_confirmation}
                         />
                 </Col>


### PR DESCRIPTION
Re: #1597
To reviewer: please check this. I'm unable to delete a test account in smc-in-smc, even before changing any code. But with code change in this PR, the `Confirm Account Deletion` button highlights properly when first name or last name is blank.