### PR TITLE
misc/mathjax: fixing off-by-one parser error and adding some tests

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1164,7 +1164,7 @@ exports.parse_mathjax = (t) ->
                     j += 1
                 j += d[1].length
                 # filter out the case, where there is just one $ in one line (e.g. command line, USD, ...)
-                at_end_of_string = j >= t.length
+                at_end_of_string = j > t.length
                 if !(d[0] == "$" and (contains_linebreak or at_end_of_string))
                     v.push([i,j])
                 i = j

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1118,6 +1118,13 @@ describe "parse_mathjax returns list of index position pairs (i,j)", ->
         pm().should.eql []
     it "correctly for $", ->
         pm("foo $bar$ batz").should.eql [[4, 9]]
+    it "works regarding issue #1795", ->
+        pm("$x_{x} x_{x}$").should.eql [[0, 13]]
+    it "ignores single $", ->
+        pm("$").should.eql []
+        pm("the amount is $100").should.eql []
+        pm("a $b$ and $").should.eql [[2, 5]]
+        pm("a $b$ and $ ignored").should.eql [[2, 5]]
     it "correctly works for multiline strings", ->
         s = """
             This is a $formula$ or a huge $$formula$$


### PR DESCRIPTION
see issue #1795 for testing chat and sagews `%md`

