### PR TITLE
Fix clipping of activity spinner

### DIFF
--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -813,7 +813,7 @@ exports.ActivityDisplay = rclass
         trunc = (s) -> misc.trunc(s, n)
         for desc, i in @props.activity
             <div key={i} style={activity_item_style} >
-                <Icon name='circle-o-notch' spin /> {trunc(desc)}
+                <Icon style={padding:'2px 1px 1px 2px'} name='circle-o-notch' spin /> {trunc(desc)}
             </div>
 
     render: ->


### PR DESCRIPTION
Tiny thing that has annoyed me.
## Unfixed:
![unfixed](https://cloud.githubusercontent.com/assets/618575/24222973/4e1ff91c-0f11-11e7-8dde-70fcba74fb7f.png)

## Fixed:
![fixed](https://cloud.githubusercontent.com/assets/618575/24222975/4e43f68c-0f11-11e7-9f4a-84d607edbd8e.png)

Also fixes the spinner "wobbling" up and down as much as I could.