### PR TITLE
support input() and pause in octave jupyter bridge

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_jupyter.py
+++ b/src/smc_sagews/smc_sagews/sage_jupyter.py
@@ -311,7 +311,9 @@ def _jkmagic(kernel_name, **kwargs):
                                 stdinj.send(xmsg)
                         except:
                             pass
-                    elif kernel_name == 'octave' and re.match('^[^#]*\W?pause', ccode):
+                    elif kernel_name == 'octave' and re.search(r"\s*pause\s*([#;\n].*)?$", ccode, re.M):
+                        # FIXME "1+2\npause\n3+4" pauses before executing any code
+                        # would need block parser here
                         p('iopub octave pause: ',ccode)
                         try:
                             # do nothing if no messsage on stdin channel within 0.5 sec


### PR DESCRIPTION
Ref:#1489

To test manually:
- Apply the patch in this PR.
- In a sagews file, run this code:

    ```
    %octave
    z = input("what is z? ","s")
    ```
    A text box should pop up in the cell output. Type in some text and hit Enter or click the checkmark at right of the text.
- The text box will be doubled. This is a known issue not related to octave or the jupyter bridge, #358 
- The value of z is echoed as `z = your_text`. You can verify this with another cell:
    ```
    %octave
    z
    ```
- In another cell, run this code:
    ```
    %octave
    pause
    3 + 4
    ```
- You will see a prompt, `Paused, enter any value to continue`. Press enter. Again, input is doubled, then you will see `ans =   100`