### PR TITLE
Clean up some differences between projects and files search behavior

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -224,10 +224,12 @@ FileRow = rclass
 
     handle_click: (e) ->
         if window.getSelection().toString() == @state.selection_at_last_mouse_down
+            foreground = misc.should_open_in_foreground(e)
             @props.actions.open_file
                 path       : @fullpath()
-                foreground : misc.should_open_in_foreground(e)
-            @props.actions.set_file_search('')
+                foreground : foreground
+            if foreground
+                @props.actions.set_file_search('')
 
     handle_download_click: (e) ->
         e.preventDefault()

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -830,7 +830,7 @@ ProjectsFilterButtons = rclass
     render_deleted_button: ->
         style = if @props.deleted then 'warning' else "default"
         if @props.show_deleted_button
-            <Button onClick={=>redux.getActions('projects').setState(deleted: not @props.deleted)} bsStyle={style}>
+            <Button onClick={=>@actions('projects').setState(deleted: not @props.deleted)} bsStyle={style}>
                 <Icon name={if @props.deleted then 'check-square-o' else 'square-o'} fixedWidth /> Deleted
             </Button>
         else
@@ -839,7 +839,7 @@ ProjectsFilterButtons = rclass
     render_hidden_button: ->
         style = if @props.hidden then 'warning' else "default"
         if @props.show_hidden_button
-            <Button onClick = {=>redux.getActions('projects').setState(hidden: not @props.hidden)} bsStyle={style}>
+            <Button onClick = {=>@actions('projects').setState(hidden: not @props.hidden)} bsStyle={style}>
                 <Icon name={if @props.hidden then 'check-square-o' else 'square-o'} fixedWidth /> Hidden
             </Button>
 
@@ -860,7 +860,7 @@ ProjectsSearch = rclass
         open_first_project : undefined
 
     clear_and_focus_input: ->
-        redux.getActions('projects').setState(search: '')
+        @actions('projects').setState(search: '')
         @refs.projects_search.clear_and_focus_search_input()
 
     delete_search_button: ->
@@ -876,7 +876,7 @@ ProjectsSearch = rclass
             type         = 'search'
             value        = {@props.search}
             placeholder  = 'Search for projects...'
-            on_change    = {(value)=>redux.getActions('projects').setState(search: value)}
+            on_change    = {(value)=>@actions('projects').setState(search: value)}
             on_submit    = {@props.open_first_project}
             button_after = {@delete_search_button()}
         />
@@ -1122,7 +1122,7 @@ ProjectList = rclass
         user_map : undefined
 
     show_all_projects: ->
-        redux.getActions('projects').setState(show_all : not @props.show_all)
+        @actions('projects').setState(show_all : not @props.show_all)
 
     render_show_all: ->
         if @props.projects.length > MAX_DEFAULT_PROJECTS
@@ -1340,6 +1340,7 @@ exports.ProjectsPage = ProjectsPage = rclass
     open_first_project: ->
         project = @visible_projects()[0]
         if project?
+            @actions('projects').setState(search : '')
             @actions('projects').open_project(project_id: project.project_id, switch_to: true)
     ###
     # Consolidate the next two functions.

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -877,7 +877,7 @@ ProjectsSearch = rclass
             value        = {@props.search}
             placeholder  = 'Search for projects...'
             on_change    = {(value)=>@actions('projects').setState(search: value)}
-            on_submit    = {@props.open_first_project}
+            on_submit    = {(_, opts)=>@props.open_first_project(not opts.ctrl_down)}
             button_after = {@delete_search_button()}
         />
 
@@ -1337,11 +1337,11 @@ exports.ProjectsPage = ProjectsPage = rclass
             marginBottom : '1ex'
         <div style={projects_title_styles}><Icon name='thumb-tack' /> Projects </div>
 
-    open_first_project: ->
+    open_first_project: (switch_to=true) ->
         project = @visible_projects()[0]
         if project?
             @actions('projects').setState(search : '')
-            @actions('projects').open_project(project_id: project.project_id, switch_to: true)
+            @actions('projects').open_project(project_id: project.project_id, switch_to: switch_to)
     ###
     # Consolidate the next two functions.
     ###


### PR DESCRIPTION
Changes in projects to match project files more closely.
- If you open a project `enter`, clear the project search
- Allow `ctrl + enter` to open a project without switching to it
- Do not clear the project search in the latter case.

Changes in project files to match projects more closely
- `ctrl + click` on a listing when searching should not clear the search.

Also remove some inappropriate usage of redux.getActions