### PR TITLE
webapp: fix absolute image URLs *between* two projects

### DIFF
--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -162,9 +162,21 @@ $.fn.process_smc_links = (opts={}) ->
                     src = y.attr(attr)
                     if not src?
                         continue
-                    if src.indexOf('://') != -1
-                        continue
                     {join} = require('path')
+                    i = src.indexOf('/projects/')
+                    j = src.indexOf('/files/')
+                    if src.indexOf(document.location.origin) == 0 and i != -1 and j != -1 and j > i
+                        # the href is inside the app, points to the current project or another one
+                        # j-i should be 36, unless we ever start to have different (vanity) project_ids
+                        path = src.slice(j + '/files/'.length)
+                        project_id = src.slice(i + '/projects/'.length, j)
+                        new_src = join('/', window.smc_base_url, project_id, 'raw', path)
+                        y.attr(attr, new_src)
+                        continue
+                    if src.indexOf('://') != -1
+                        # link points somewhere else
+                        continue
+                    # we do not have an absolute url, hence we assume it is a relative URL to a file in a project
                     new_src = join('/', window.smc_base_url, opts.project_id, 'raw', opts.file_path, src)
                     y.attr(attr, new_src)
 


### PR DESCRIPTION
this deals with issue #1778 

process: capture the special case of absolute URLs, extract the project_id and path, and reconstruct the "raw" URL.

test: you're a collab on projects A and B. Given in project A is a "plot.png" file, reference it from project B via `https:// ... /projects/project_A/file/.../plot.png` in a chat message or a MD file.

time: 20 min