### PR TITLE
webapp/latex: content sometimes undefined

### DIFF
--- a/src/smc-webapp/editor_latex.coffee
+++ b/src/smc-webapp/editor_latex.coffee
@@ -519,6 +519,11 @@ class exports.LatexEditor extends editor.FileEditor
             return
 
         content = @_get()
+        # issue #1814
+        if not content?
+            cb?()
+            return
+
         if not force and content == @_last_update_preview
             cb?()
             return


### PR DESCRIPTION
see issue #1814

process: this is a simple defensive solution, the real question is what's going on with `@_get()`

time: 5 min