### PR TITLE
webapp: email share the url encoded link, while not url encoding the whole url

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1536,9 +1536,8 @@ ProjectFilesActionBox = rclass
             when 'google'
                 url = "https://plus.google.com/share?url=#{public_url}"
             when 'email'
-                # don't do encodeURIComponent -- strangely messes up everything for email
                 url = """mailto:?to=&subject=#{filename} on SageMathCloud&
-                body=A file is shared with you: #{file_url}"""
+                body=A file is shared with you: #{public_url}"""
         if url?
             {open_popup_window} = require('./misc_page')
             open_popup_window(url)


### PR DESCRIPTION
issue #1812

process: the comment was referring to encoding the whole string, but it's ok to use the already encoded link to the path. simple error in reasoning.

test: create a crazily named file `file with spä¢→al-¢ħæ¶ſ.md` and share it via the file listing. when clicking on email, an encoded url shows up. copy/paste it back into your web-browser to see if it opens up fine.

time: 10 min