### PR TITLE
Clean up SearchInput and extra markup

### DIFF
--- a/src/smc-webapp/course/assignments_panel.cjsx
+++ b/src/smc-webapp/course/assignments_panel.cjsx
@@ -10,7 +10,7 @@ misc = require('smc-util/misc')
 # SMC and course components
 course_funcs = require('./course_funcs')
 styles = require('./styles')
-{DateTimePicker, ErrorDisplay, Icon, LabeledRow, Loading, MarkdownInput, SearchInput, Tip, NumberInput} = require('../r_misc')
+{DateTimePicker, ErrorDisplay, Icon, LabeledRow, Loading, MarkdownInput, Tip, NumberInput} = require('../r_misc')
 {STEPS, step_direction, step_verb, step_ready,
     BigTime, FoldersToolbar, StudentAssignmentInfo, StudentAssignmentInfoHeader} = require('./common')
 

--- a/src/smc-webapp/course/common.cjsx
+++ b/src/smc-webapp/course/common.cjsx
@@ -369,7 +369,7 @@ exports.StudentAssignmentInfo = rclass
 exports.MultipleAddSearch = MultipleAddSearch = rclass
     propTypes :
         add_selected     : rtypes.func.isRequired   # Submit user selected results add_selected(['paths', 'of', 'folders'])
-        do_search        : rtypes.func.isRequired   # Submit search query
+        do_search        : rtypes.func.isRequired   # Submit search query, invoked as do_search(value)
         clear_search     : rtypes.func.isRequired
         is_searching     : rtypes.bool.isRequired   # whether or not it is asking the backend for the result of a search
         search_results   : rtypes.immutable.List    # contents to put in the selection box after getting search result back
@@ -463,7 +463,7 @@ exports.MultipleAddSearch = MultipleAddSearch = rclass
                 default_value = ''
                 placeholder   = "Add #{@props.item_name} by folder name (enter to see available folders)..."
                 on_submit     = {@props.do_search}
-                on_escape     = {@clear_and_focus_search_input}
+                on_clear      = {@clear_and_focus_search_input}
                 buttonAfter   = {@search_button()}
             />
             {@render_add_selector() if @state.show_selector}

--- a/src/smc-webapp/course/handouts_panel.cjsx
+++ b/src/smc-webapp/course/handouts_panel.cjsx
@@ -11,7 +11,7 @@ misc = require('smc-util/misc')
 course_funcs = require('./course_funcs')
 styles = require('./styles')
 {BigTime, FoldersToolbar} = require('./common')
-{ErrorDisplay, Icon, Tip, SearchInput, MarkdownInput} = require('../r_misc')
+{ErrorDisplay, Icon, Tip, MarkdownInput} = require('../r_misc')
 
 # Could be merged with steps system of assignments.
 # Probably not a good idea mixing the two.

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -56,7 +56,7 @@ schema = require('smc-util/schema')
     Panel, Popover, Tabs, Tab, Well} = require('react-bootstrap')
 
 {ActivityDisplay, ErrorDisplay, Help, Icon, Loading,
-    SaveButton, SearchInput, SelectorInput, Space, TextInput, TimeAgo, NumberInput} = require('../r_misc')
+    SaveButton, SelectorInput, Space, TextInput, TimeAgo, NumberInput} = require('../r_misc')
 
 # Course components
 #{CourseActions} = require('./course_editor_components/actions')

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1753,13 +1753,13 @@ ProjectFilesSearch = rclass
                     foreground : not opts.ctrl_down
             if opening_a_dir or not opts.ctrl_down
                 @props.actions.set_file_search('')
-                @props.actions.reset_selected_file_index()
+                @props.actions.clear_selected_file_index()
         else if @props.file_search.length > 0
             if @props.file_search[@props.file_search.length - 1] == '/'
                 @props.create_folder(not opts.ctrl_down)
             else
                 @props.create_file(null, not opts.ctrl_down)
-            @props.actions.reset_selected_file_index()
+            @props.actions.clear_selected_file_index()
 
     on_up_press: ->
         if @props.selected_file_index > 0
@@ -1770,7 +1770,7 @@ ProjectFilesSearch = rclass
             @props.actions.increment_selected_file_index()
 
     on_change: (search, opts) ->
-        @props.actions.reset_selected_file_index()
+        @props.actions.zero_selected_file_index()
         @props.actions.set_file_search(search)
 
     on_clear: ->

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1769,11 +1769,10 @@ ProjectFilesSearch = rclass
             @props.actions.increment_selected_file_index()
 
     on_change: (search, opts) ->
-        if not opts.ctrl_down
-            @props.actions.reset_selected_file_index()
+        @props.actions.reset_selected_file_index()
         @props.actions.set_file_search(search)
 
-    on_escape: () ->
+    on_clear: ->
         @setState(input: '', stdout:'', error:'')
 
     render: ->
@@ -1787,7 +1786,7 @@ ProjectFilesSearch = rclass
                 on_submit   = {@search_submit}
                 on_up       = {@on_up_press}
                 on_down     = {@on_down_press}
-                on_escape   = {@on_escape}
+                on_clear    = {@on_clear}
             />
             {@render_file_creation_error()}
             {@render_help_info()}

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1743,14 +1743,15 @@ ProjectFilesSearch = rclass
             @execute_command(command)
         else if @props.selected_file
             new_path = misc.path_to_file(@props.current_path, @props.selected_file.name)
-            if @props.selected_file.isdir
+            opening_a_dir = @props.selected_file.isdir
+            if opening_a_dir
                 @props.actions.open_directory(new_path)
                 @props.actions.setState(page_number: 0)
             else
                 @props.actions.open_file
                     path: new_path
                     foreground : not opts.ctrl_down
-            if not opts.ctrl_down
+            if opening_a_dir or not opts.ctrl_down
                 @props.actions.set_file_search('')
                 @props.actions.reset_selected_file_index()
         else if @props.file_search.length > 0
@@ -1760,11 +1761,11 @@ ProjectFilesSearch = rclass
                 @props.create_file(null, not opts.ctrl_down)
             @props.actions.reset_selected_file_index()
 
-    on_up_press: () ->
+    on_up_press: ->
         if @props.selected_file_index > 0
             @props.actions.decrement_selected_file_index()
 
-    on_down_press: () ->
+    on_down_press: ->
         if @props.selected_file_index < @props.num_files_displayed - 1
             @props.actions.increment_selected_file_index()
 

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -574,7 +574,7 @@ FileListing = rclass
             color = '#eee'
         else
             color = 'white'
-        apply_border = index == @props.selected_file_index and @props.file_search.length > 0 and @props.file_search[0] isnt TERM_MODE_CHAR
+        apply_border = index == @props.selected_file_index and @props.file_search[0] isnt TERM_MODE_CHAR
         if isdir
             return <DirectoryRow
                 name         = {name}
@@ -1898,7 +1898,6 @@ exports.ProjectFiles = rclass ({name}) ->
         page_number : 0
         file_search : ''
         new_name : ''
-        selected_file_index : 0
         actions : redux.getActions(name) # TODO: Do best practices way
         redux   : redux
 
@@ -2199,7 +2198,7 @@ exports.ProjectFiles = rclass ({name}) ->
                         file_search         = {@props.file_search}
                         actions             = {@props.actions}
                         current_path        = {@props.current_path}
-                        selected_file       = {visible_listing?[@props.selected_file_index]}
+                        selected_file       = {visible_listing?[@props.selected_file_index ? 0]}
                         selected_file_index = {@props.selected_file_index}
                         file_creation_error = {@props.file_creation_error}
                         num_files_displayed = {visible_listing?.length}

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1774,6 +1774,7 @@ ProjectFilesSearch = rclass
         @props.actions.set_file_search(search)
 
     on_clear: ->
+        @props.actions.clear_selected_file_index()
         @setState(input: '', stdout:'', error:'')
 
     render: ->

--- a/src/smc-webapp/project_search.cjsx
+++ b/src/smc-webapp/project_search.cjsx
@@ -24,7 +24,7 @@ underscore = require('underscore')
 {React, ReactDOM, Actions, Store, rtypes, rclass, Redux}  = require('./smc-react')
 
 {Col, Row, Button, FormControl, FormGroup, Well, InputGroup, Alert, Checkbox} = require('react-bootstrap')
-{Icon, Loading, Space, ImmutablePureRenderMixin} = require('./r_misc')
+{Icon, Loading, SearchInput, Space, ImmutablePureRenderMixin} = require('./r_misc')
 misc            = require('smc-util/misc')
 misc_page       = require('./misc_page')
 {salvus_client} = require('./salvus_client')
@@ -40,47 +40,28 @@ ProjectSearchInput = rclass
         user_input : rtypes.string.isRequired
         actions    : rtypes.object.isRequired
 
-    clear_and_focus_input: ->
+    clear_output: ->
         @props.actions.setState
-            user_input         : ''
             most_recent_path   : undefined
             command            : undefined
             most_recent_search : undefined
             search_results     : undefined
             search_error       : undefined
 
-        ReactDOM.findDOMNode(@refs.project_search_input).focus()
-
-    clear_button: ->
-        <Button onClick={@clear_and_focus_input}>
-            <Icon name='times-circle' />
-        </Button>
-
-    handle_change: ->
-        user_input = ReactDOM.findDOMNode(@refs.project_search_input).value
-        @props.actions.setState(user_input : user_input)
-
-    submit: (event) ->
-        event.preventDefault()
-        @props.actions.search()
+    handle_change: (value) ->
+        @props.actions.setState(user_input : value)
 
     render: ->
-        <form onSubmit={@submit}>
-            <FormGroup>
-                <InputGroup>
-                    <FormControl
-                        ref         = 'project_search_input'
-                        autoFocus
-                        type        = 'text'
-                        placeholder = 'Enter search (supports regular expressions!)'
-                        value       = {@props.user_input}
-                        onChange    = {@handle_change} />
-                    <InputGroup.Button>
-                        {@clear_button()}
-                    </InputGroup.Button>
-                </InputGroup>
-            </FormGroup>
-        </form>
+        <SearchInput
+            ref         = 'project_search_input'
+            autoFocus   = {true}
+            type        = 'search'
+            value       = {@props.user_input}
+            placeholder = 'Enter search (supports regular expressions!)'
+            on_change   = {@handle_change}
+            on_submit   = {@props.actions.search}
+            on_clear    = {@clear_output}
+        />
 
 ProjectSearchOutput = rclass
     displayName : 'ProjectSearch-ProjectSearchOutput'

--- a/src/smc-webapp/project_settings.cjsx
+++ b/src/smc-webapp/project_settings.cjsx
@@ -870,8 +870,7 @@ CollaboratorsSearch = rclass
                     default_value   = {@state.search}
                     placeholder     = 'Search by name or email address...'
                     on_change       = {(value) => @setState(select:undefined)}
-                    on_escape       = {@reset}
-                    clear_on_submit = {true}
+                    on_clear        = {@reset}
                 />
             </LabeledRow>
             {@render_search()}

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -647,20 +647,22 @@ class ProjectActions extends Actions
         )
 
     # Increases the selected file index by 1
-    # Assumes undefined state to be identical to 0
+    # undefined increments to 0
     increment_selected_file_index: ->
-        current_index = @get_store().selected_file_index ? 0
+        current_index = @get_store().selected_file_index ? -1
         @setState(selected_file_index : current_index + 1)
 
     # Decreases the selected file index by 1.
     # Guaranteed to never set below 0.
+    # Does nothing when selected_file_index is undefined
     decrement_selected_file_index: ->
         current_index = @get_store().selected_file_index
         if current_index? and current_index > 0
             @setState(selected_file_index : current_index - 1)
 
+    # Sets to undefined meaning there is none
     reset_selected_file_index: ->
-        @setState(selected_file_index : 0)
+        @setState(selected_file_index : undefined)
 
     # Set the most recently clicked checkbox, expects a full/path/name
     set_most_recent_file_click: (file) =>

--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -660,8 +660,10 @@ class ProjectActions extends Actions
         if current_index? and current_index > 0
             @setState(selected_file_index : current_index - 1)
 
-    # Sets to undefined meaning there is none
-    reset_selected_file_index: ->
+    zero_selected_file_index: ->
+        @setState(selected_file_index : 0)
+
+    clear_selected_file_index: ->
         @setState(selected_file_index : undefined)
 
     # Set the most recently clicked checkbox, expects a full/path/name
@@ -1345,7 +1347,7 @@ create_project_store_def = (name, project_id) ->
         show_hidden            : rtypes.bool
         error                  : rtypes.string
         checked_files          : rtypes.immutable
-        selected_file_index    : rtypes.number
+        selected_file_index    : rtypes.number     # Index on file listing to highlight starting at 0. undefined means none highlighted
         new_name               : rtypes.string
         sort_by_time           : rtypes.bool
         most_recent_file_click : rtypes.string

--- a/src/smc-webapp/projects.cjsx
+++ b/src/smc-webapp/projects.cjsx
@@ -859,26 +859,14 @@ ProjectsSearch = rclass
         search             : ''
         open_first_project : undefined
 
-    clear_and_focus_input: ->
-        @actions('projects').setState(search: '')
-        @refs.projects_search.clear_and_focus_search_input()
-
-    delete_search_button: ->
-        s = if @props.search?.length > 0 then 'warning' else "default"
-        <Button onClick={@clear_and_focus_input} bsStyle={s}>
-            <Icon name='times-circle' />
-        </Button>
-
     render: ->
         <SearchInput
-            ref          = 'projects_search'
-            autoFocus    = {true}
-            type         = 'search'
-            value        = {@props.search}
-            placeholder  = 'Search for projects...'
-            on_change    = {(value)=>@actions('projects').setState(search: value)}
-            on_submit    = {(_, opts)=>@props.open_first_project(not opts.ctrl_down)}
-            button_after = {@delete_search_button()}
+            ref         = 'projects_search'
+            autoFocus   = {true}
+            value       = {@props.search}
+            placeholder = 'Search for projects...'
+            on_change   = {(value)=>@actions('projects').setState(search: value)}
+            on_submit   = {(_, opts)=>@props.open_first_project(not opts.ctrl_down)}
         />
 
 HashtagGroup = rclass

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -527,23 +527,26 @@ exports.TimeAgo = rclass
 # with callbacks, and value for a controlled one!
 #    See http://facebook.github.io/react/docs/forms.html#controlled-components
 
-# Search input box with a clear button (that focuses!), enter to submit,
-# escape to also clear.
+# Search input box with the following capabilities
+# a clear button (that focuses the input)
+# `enter` to submit
+# `esc` to clear
 exports.SearchInput = rclass
     displayName : 'Misc-SearchInput'
 
     propTypes :
+        autoFocus       : rtypes.bool
+        autoSelect      : rtypes.bool
         placeholder     : rtypes.string
         default_value   : rtypes.string
         value           : rtypes.string
-        on_change       : rtypes.func    # called on_change(value, get_opts()) each time the search input changes
-        on_submit       : rtypes.func    # called on_submit(value, get_opts()) when the search input is submitted (by hitting enter)
-        on_escape       : rtypes.func    # called when user presses escape key; on_escape(value *before* hitting escape)
-        autoFocus       : rtypes.bool
-        autoSelect      : rtypes.bool
+        on_change       : rtypes.func    # invoked as on_change(value, get_opts()) each time the search input changes
+        on_submit       : rtypes.func    # invoked as on_submit(value, get_opts()) when the search input is submitted (by hitting enter)
+        on_escape       : rtypes.func    # invoked when user presses escape key; on_escape(value *before* hitting escape)
         on_up           : rtypes.func    # push up arrow
         on_down         : rtypes.func    # push down arrow
-        clear_on_submit : rtypes.bool    # if true, will clear search box on submit (default: false)
+        on_clear        : rtypes.func    # invoked without arguments when input box is cleared (eg. via esc or clicking the clear button)
+        clear_on_submit : rtypes.bool    # if true, will clear search box on every submit (default: false)
         buttonAfter     : rtypes.object
 
     getInitialState: ->
@@ -564,8 +567,12 @@ exports.SearchInput = rclass
             catch e
                 # Edge sometimes complains about 'Could not complete the operation due to error 800a025e'
 
-    clear_and_focus_search_input: ->
+    clear_value: ->
         @set_value('')
+        @props.on_clear?()
+
+    clear_and_focus_search_input: ->
+        @clear_value()
         ReactDOM.findDOMNode(@refs.input).focus()
 
     search_button: ->
@@ -583,10 +590,10 @@ exports.SearchInput = rclass
 
     submit: (e) ->
         e?.preventDefault()
-        @props.on_change?(@state.value, @get_opts())
         @props.on_submit?(@state.value, @get_opts())
         if @props.clear_on_submit
-            @setState(value:'')
+            @clear_value()
+            @props.on_change?(@state.value, @get_opts())
 
     key_down: (e) ->
         switch e.keyCode

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -615,7 +615,7 @@ exports.SearchInput = rclass
 
     escape: ->
         @props.on_escape?(@state.value)
-        @set_value('')
+        @clear_value()
 
     render: ->
         <FormGroup>

--- a/src/smc-webapp/support.cjsx
+++ b/src/smc-webapp/support.cjsx
@@ -22,7 +22,7 @@ $          = window.$
 underscore = _ = require('underscore')
 {React, ReactDOM, Actions, Store, rtypes, rclass, redux, COLOR}  = require('./smc-react')
 {Col, Row, Button, FormControl, FormGroup, Well, Alert, Modal, Table} = require('react-bootstrap')
-{Icon, Markdown, Loading, SearchInput, Space, ImmutablePureRenderMixin, Footer} = require('./r_misc')
+{Icon, Markdown, Loading, Space, ImmutablePureRenderMixin, Footer} = require('./r_misc')
 misc            = require('smc-util/misc')
 misc_page       = require('./misc_page')
 {salvus_client} = require('./salvus_client')


### PR DESCRIPTION
Cleans up what I think are the final holes for SearchInput.

- Removes extraneous markup and unifies search inputs fixing various small bugs.
  - For example the project search icon now correctly becomes orange when non-empty 
- Opening a directory now clears the search input since in most cases, you are not looking for something with the same name as the directory you searched for.
- Allows `↓` to trigger selection highlighting in project files.
- Improve readability of selected_file_index manipulations.