### PR TITLE
misc/mathjax: detecting all mathjax environments -- fixes #1822

### DIFF
--- a/src/smc-util/misc.coffee
+++ b/src/smc-util/misc.coffee
@@ -1122,16 +1122,15 @@ exports.parse_hashtags = (t) ->
                 base += i+1
                 t = t.slice(i+1)
 
-mathjax_delim = [['$$','$$'], ['\\(','\\)'], ['\\[','\\]'],
-                 ['\\begin{equation}', '\\end{equation}'],
-                 ['\\begin{equation*}', '\\end{equation*}'],
-                 ['\\begin{align}', '\\end{align}'],
-                 ['\\begin{align*}', '\\end{align*}'],
-                 ['\\begin{eqnarray}', '\\end{eqnarray}'],
-                 ['\\begin{eqnarray*}', '\\end{eqnarray*}'],
-                 ['\\begin{bmatrix}', '\\end{bmatrix}']
-                 ['$', '$']  # must be after $$
-                ]
+# see http://docs.mathjax.org/en/latest/tex.html#environments
+mathjax_environments = ['align', 'align*', 'alignat', 'alignat*', 'aligned', 'alignedat', 'array', \
+                        'Bmatrix', 'bmatrix', 'cases', 'CD', 'eqnarray', 'eqnarray*', 'equation', 'equation*', \
+                        'gather', 'gather*', 'gathered', 'matrix', 'multline', 'multline*', 'pmatrix', 'smallmatrix', \
+                        'split', 'subarray', 'Vmatrix', 'vmatrix']
+mathjax_delim = [['$$','$$'], ['\\(','\\)'], ['\\[','\\]']]
+for env in mathjax_environments
+    mathjax_delim.push(["\\begin{#{env}}", "\\end{#{env}}"])
+mathjax_delim.push(['$', '$'])  # must be after $$, best to put it at the end
 
 exports.parse_mathjax = (t) ->
     # Return list of pairs (i,j) such that t.slice(i,j) is a mathjax, including delimiters.

--- a/src/smc-util/test/misc-test.coffee
+++ b/src/smc-util/test/misc-test.coffee
@@ -1146,6 +1146,9 @@ describe "parse_mathjax returns list of index position pairs (i,j)", ->
         pm('\\begin{align*}foobar\\end{align*}').should.eql [[0, 32]]
         pm('\\begin{eqnarray}foobar\\end{eqnarray}').should.eql [[0, 36]]
         pm('\\begin{eqnarray*}foobar\\end{eqnarray*}').should.eql [[0, 38]]
+        pm('\\begin{bmatrix}foobar\\end{bmatrix}').should.eql [[0, 34]]
+    it "is not triggered by unknown environments", ->
+        pm('\\begin{cmatrix}foobar\\end{cmatrix}').should.eql []
 
 describe "replace_all", ->
     ra = misc.replace_all


### PR DESCRIPTION
see #1822 

test: with that fix, even monstrosities like the following are rendered properly in a `*.md` file.

```
\begin{CD}
(0,0) @         >1/2>>       (1,0) @>1/3>>           (2,0) @.                  @.                  @.                  @.                 \\
      @V 1/2 VV                    @V2/3 VV                @V1 VV              @.                  @.                  @.            @.   \\
(1,1) @         >2/3>>       (2,1) @>1/2>>           (3,1) @.                  @.                  @.                  @.                 \\
      @V 1/3 VV                    @V1/2 VV                @V1 VV              @.                  @.                  @.            @.   \\
(2,2) @         > 1 >>       (3,2) @>1/2>>           (4,2) @>1/2>>        (5,2)@>1/3>>        (6,2)@.                  @.                 \\
      @.                           @.                      @V1/2VV             @V2/3VV             @V1 VV              @.            @.   \\
      @.                           @.                (5,3) @>2/3>>        (6,3)@>1/2>>        (7,3)@.                  @.
\end{CD}
```

time: 15 min

process: carefully copy+adapt the list of environments from the mathjax documentation, add two tests, all pass, and check the above in my dev project.