### PR TITLE
webapp/sagews: making the %latex buttonbar a bit smarter and some enhancements

### DIFF
--- a/src/smc-webapp/buttonbar.coffee
+++ b/src/smc-webapp/buttonbar.coffee
@@ -250,6 +250,18 @@ exports.commands =
             wrap :
                 left  : '\\underline{'
                 right : '}'
+        strikethrough :       # requires the soul package
+            wrap :
+                left  : '\\st{'
+                right : '}'
+        equation :
+            wrap :
+                left  : "$"
+                right : "$"
+        display_equation :
+            wrap :
+                left  : "$$"
+                right : "$$"
         insertunorderedlist :
             wrap :
                 left  : "\\begin{itemize}\n    \\item\n"
@@ -478,12 +490,12 @@ exports.commands =
                 right : '</pre>'
         equation :
             wrap :
-                left  : "$ "
-                right : " $"
+                left  : "$"
+                right : "$"
         display_equation :
             wrap :
-                left  : "$$ "
-                right : " $$"
+                left  : "$$"
+                right : "$$"
         table:
             wrap:
                 left  : """

--- a/src/smc-webapp/editor.coffee
+++ b/src/smc-webapp/editor.coffee
@@ -1690,6 +1690,7 @@ class CodeMirrorEditor extends FileEditor
     # Editor button bar support code
     ############
     textedit_command: (cm, cmd, args) =>
+        # ATTN when adding more cases, also edit textedit_only_show_known_buttons
         switch cmd
             when "link"
                 cm.insert_link(cb:() => @syncdoc?.sync())
@@ -1824,6 +1825,23 @@ class CodeMirrorEditor extends FileEditor
         @_current_mode = "sage"
         @mode_display.show()
 
+        # not all textedit buttons are known
+        textedit_only_show_known_buttons = (name) =>
+            EDIT_COMMANDS = require('./buttonbar').commands
+            {sagews_canonical_mode} = require('./misc_page')
+            default_mode = @focused_codemirror()?.get_edit_mode() ? 'sage'
+            mode = sagews_canonical_mode(name, default_mode)
+            #if DEBUG then console.log "textedit_only_show_known_buttons: mode #{name} → #{mode}"
+            known_commands = misc.keys(EDIT_COMMANDS[mode] ? {})
+            # see special cases in 'textedit_command' and misc_page: 'edit_selection'
+            known_commands = known_commands.concat(['link', 'image', 'SpecialChar', 'font_size'])
+            for button in @textedit_buttons.find('a')
+                button = $(button)
+                cmd = button.attr('href').slice(1)
+                # in theory, this should also be done for html&md, but there are many more special cases
+                # therefore we just make sure they're all activated again
+                button.toggle((mode != 'tex') or (cmd in known_commands))
+
         set_mode_display = (name) =>
             #console.log("set_mode_display: #{name}")
             if name?
@@ -1833,9 +1851,11 @@ class CodeMirrorEditor extends FileEditor
             mode_display.text("%" + mode)
             @_current_mode = mode
 
-        show_edit_buttons = (which_one, name) ->
+        show_edit_buttons = (which_one, name) =>
             for edit_buttons in all_edit_buttons
                 edit_buttons.toggle(edit_buttons == which_one)
+            if which_one == @textedit_buttons
+                textedit_only_show_known_buttons(name)
             set_mode_display(name)
 
         mode_display.click(@wizard_handler)

--- a/src/smc-webapp/misc_page.coffee
+++ b/src/smc-webapp/misc_page.coffee
@@ -563,6 +563,27 @@ exports.cm_define_testbot = (cm) ->
                 setTimeout(f, opts.delay)
         f()
 
+exports.sagews_canonical_mode = (name, default_mode) ->
+    switch name
+        when 'markdown'
+            return 'md'
+        when 'xml'
+            return 'html'
+        when 'mediawiki'
+            return 'mediawiki'
+        when 'stex'
+            return 'tex'
+        when 'python'
+            return 'python'
+        when 'r'
+            return 'r'
+        when 'sagews'
+            return 'sage'
+        when 'shell'
+            return 'shell'
+        else
+            return default_mode
+
 exports.define_codemirror_extensions = () ->
 
     # LaTeX code folding (isn't included in CodeMirror)
@@ -1015,25 +1036,7 @@ exports.define_codemirror_extensions = () ->
             default_mode = cm.get_edit_mode()
 
         canonical_mode = (name) ->
-            switch name
-                when 'markdown'
-                    return 'md'
-                when 'xml'
-                    return 'html'
-                when 'mediawiki'
-                    return 'mediawiki'
-                when 'stex'
-                    return 'tex'
-                when 'python'
-                    return 'python'
-                when 'r'
-                    return 'r'
-                when 'sagews'
-                    return 'sage'
-                when 'shell'
-                    return 'shell'
-                else
-                    return default_mode
+            exports.sagews_canonical_mode(name, default_mode)
 
         args = opts.args
         cmd = opts.cmd
@@ -1079,6 +1082,9 @@ exports.define_codemirror_extensions = () ->
                     # Sage fallback in python mode. FUTURE: There should be a Sage mode.
                     mode1 = "sage"
                 how = EDIT_COMMANDS[mode1][cmd]
+
+            if DEBUG and not how?
+                console.warn("CodeMirror/edit_selection: unknown 'how' for mode1='#{mode1}' and cmd='#{cmd}'")
 
             # trim whitespace
             i = 0
@@ -1159,6 +1165,13 @@ exports.define_codemirror_extensions = () ->
                             src = src1
                     if args != '3'
                         src = "<font size=#{args}>#{src}</font>"
+                else if mode == 'tex'
+                    # we need 6 latex sizes, for size 1 to 7 (default 3, at index 2)
+                    latex_sizes = ['tiny', 'footnotesize', 'normalsize', 'large', 'LARGE', 'huge', 'Huge']
+                    i = parseInt(args)
+                    if i in [1..7]
+                        size = latex_sizes[i - 1]
+                        src = "{\\#{size} #{src}}"
 
             if cmd == 'color'
                 if mode in ['html', 'md', 'mediawiki']

--- a/src/smc_sagews/smc_sagews/sage_salvus.py
+++ b/src/smc_sagews/smc_sagews/sage_salvus.py
@@ -1463,6 +1463,7 @@ def latex0(s=None, **kwds):
         kwds['locals'] = salvus.namespace
     if 'globals' not in kwds:
         kwds['globals'] = salvus.namespace
+    sage.misc.latex.latex.add_package_to_preamble_if_available('soul')
     sage.misc.latex.Latex.eval(sage.misc.latex.latex, s, **kwds)
     salvus.file(kwds['filename'], once=False)
     if delete_file:


### PR DESCRIPTION
issue #1565

This isn't pretty, but it hides the undefined latex buttons. There are also new features like font size, and also striking through text. That in turn needs the `sout` package. Hence my question: @DrXyzzy do you know if the line `...latex.add_package_to_preamble_if_available('soul')` in `smc_sagews/sage_salvus.py` makes sense? It works for my dev project, so I'm quite sure it is at least heading into the right direction.

process: untangling the labyrinth of buttonbar commands, their special cases and fallbacks, reading what CodeMirror's `edit_selection` in misc_page does and adding more code to handle more latex commands.

test: in a sagews, make a `%latex` cell and click all the buttons. bonus feature: in debug mode, `edit_selection` will give a warning if it doesn't know what to do (no `how?`).

time: 75 min
