### PR TITLE
change url for mathjax CDN #1845

### DIFF
--- a/src/smc-webapp/printing.coffee
+++ b/src/smc-webapp/printing.coffee
@@ -294,7 +294,7 @@ class SagewsPrinter extends Printer
 
                     <script type="text/javascript">window.MathJax = #{misc.to_json(MathJaxConfig)};</script>
                     <script type="text/javascript" async
-                        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+                        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML">
                     </script>
                 </head>
 


### PR DESCRIPTION
Updated url per #1845.

Tested by introducing deliberate typo in the MathJax CDN URL and confirming that clicking print button at upper right for a sage worksheet did not produce LaTeX output, fixing the typo and seeing correct LaTeX in the HTML produced by clicking print.

time: 30 minutes