### PR TITLE
sagews: use a lexer to parse codeblocks for stripping comments and "understanding" strings

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -961,12 +961,19 @@ class Salvus(object):
             sys.stdout.reset(); sys.stderr.reset()
             try:
                 b = block.rstrip()
+                # get rid of comments at the end of the line -- issue #1835
+                from shlex import shlex
+                s = shlex(b)
+                s.commenters = '#'
+                s.quotes = '''"\''''
+                b = ''.join(s)
+                # e.g. now a line like 'x = test?   # bar' becomes 'x=test?'
                 if b.endswith('??'):
-                    p = sage_parsing.introspect(block,
+                    p = sage_parsing.introspect(b,
                                    namespace=namespace, preparse=False)
                     self.code(source = p['result'], mode = "python")
                 elif b.endswith('?'):
-                    p = sage_parsing.introspect(block, namespace=namespace, preparse=False)
+                    p = sage_parsing.introspect(b, namespace=namespace, preparse=False)
                     self.code(source = p['result'], mode = "text/x-rst")
                 else:
                     reload_attached_files_if_mod_smc()

--- a/src/smc_sagews/smc_sagews/tests/conftest.py
+++ b/src/smc_sagews/smc_sagews/tests/conftest.py
@@ -373,6 +373,35 @@ def data_path(tmpdir_factory):
     return path
 
 @pytest.fixture()
+def execdoc(request, sagews, test_id):
+    r"""
+    Fixture function execdoc. Depends on two other fixtures, sagews and test_id.
+
+    EXAMPLES:
+
+    ::
+
+        def test_assg(execdoc):
+            execdoc("random?")
+    """
+    def execfn(code, pattern='Docstring'):
+        m = message.execute_code(code = code, id = test_id)
+        sagews.send_json(m)
+        typ, mesg = sagews.recv()
+        assert typ == 'json'
+        assert mesg['id'] == test_id
+        assert 'code' in mesg
+        assert 'source' in mesg['code']
+        assert re.sub('\s+','',pattern) in re.sub('\s+','',mesg['code']['source'])
+
+    def fin():
+        recv_til_done(sagews, test_id)
+
+    request.addfinalizer(fin)
+    return execfn
+
+
+@pytest.fixture()
 def exec2(request, sagews, test_id):
     r"""
     Fixture function exec2. Depends on two other fixtures, sagews and test_id.

--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -7,6 +7,16 @@ import re
 
 from textwrap import dedent
 
+class TestLex:
+    def test_lex_1(self, execdoc):
+        execdoc("x = random? # bar")
+    def test_lex_2(self, execdoc):
+        execdoc("x = random? # plot?")
+    def test_lex_3(self, exec2):
+        exec2("x = 1 # plot?\nx","1\n")
+    def test_lex_4(self, exec2):
+        exec2('x="random?" # plot?\nx',"'random?'\n")
+
 class TestDecorators:
     def test_simple_dec(self, exec2):
         code = dedent(r"""
@@ -118,19 +128,9 @@ class TestBasic:
         html = "https://www.google.com/search\?q=site%3Adoc.sagemath.org\+laurent\&oq=site%3Adoc.sagemath.org"
         exec2(code, html_pattern = html)
 
-    def test_show_doc(self, test_id, sagews):
+    def test_show_doc(self, execdoc):
         # issue 476
-        code = "show?"
-        patn = "import smc_sagews.graphics\nsmc_sagews.graphics.graph_to_d3_jsonable?"
-        m = conftest.message.execute_code(code = code, id = test_id)
-        sagews.send_json(m)
-        typ, mesg = sagews.recv()
-        assert typ == 'json'
-        assert mesg['id'] == test_id
-        assert 'code' in mesg
-        assert 'source' in mesg['code']
-        assert re.sub('\s+','',patn) in re.sub('\s+','',mesg['code']['source'])
-        conftest.recv_til_done(sagews, test_id)
+        execdoc("show?")
 
     # https://github.com/sagemathinc/smc/issues/1107
     def test_sage_underscore_1(self, exec2):


### PR DESCRIPTION
see issue #1835

This is one way how how to deal with this. Part of this is to come up with a list of code-strings to test:

* `sage_server?` → docstring
* `x = random?   # bar` → docstring for random
* `x = random?   # plot?` → still docstring for random, not plot
* `x = 1 # plot?` → no docstring, x is 1
* `x="random?" # plot?` → assign x, no docstring for plot
* ```
  x = """
  salvus?
  """
  ``` 
  x is this multiline string, no help for salvus.

@DrXyzzy apart from the obvious fact that this is in the need for proper test cases, please check if I have missed something. I am also not sure if it doesn't break something else. I.e. note that the `sage_parsing.introspect` do get `b` now, and no longer the `block`. That's necessary, because otherwise it doesn't introspect correctly.

process: investigating a few techniques and tuning shlex in a way that it covers many (all?) cases.

time: 1 hour