### PR TITLE
util/sync: taking care of @get_doc returning undefined

### DIFF
--- a/src/smc-util/syncstring.coffee
+++ b/src/smc-util/syncstring.coffee
@@ -1519,7 +1519,7 @@ class SyncDoc extends EventEmitter
                         if err
                             cb(err)
                         else if not exists
-                            dbg("write '#{path}' to disk from syncstring in-memory database version -- '#{@get_doc().slice(0,80)}...'")
+                            dbg("write '#{path}' to disk from syncstring in-memory database version -- '#{@get_doc()?.slice(0,80)}...'")
                             @_client.write_file
                                 path : path
                                 data : @to_str()


### PR DESCRIPTION
issue #1855 

process: simple fix. if it returns undefined, instead of an exception the string "undefined" will be  shown.

time: 5 min