### PR TITLE
Allow course emails to be edited by instructors

### DIFF
--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -460,16 +460,24 @@ init_redux = (course_filename, redux, course_project_id) ->
                 is_descending = false
             @setState(active_student_sort : {column_name, is_descending})
 
-        set_internal_student_name: (student, first_name, last_name) =>
+        set_internal_student_info: (student, info) =>
             store = get_store()
             return if not store?
             student = store.get_student(student)
+
+            info = defaults info,
+                first_name    : required
+                last_name     : required
+                email_address : student.get('email_address')
+
             @_set
-                first_name : first_name
-                last_name  : last_name
-                student_id : student.get('student_id')
-                table      : 'students'
+                first_name    : info.first_name
+                last_name     : info.last_name
+                email_address : info.email_address
+                student_id    : student.get('student_id')
+                table         : 'students'
             @configure_all_projects()   # since they may get removed from shared project, etc.
+
 
         # Student projects
 

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -430,17 +430,20 @@ Student = rclass
             @setState(edited_first_name : next.student_name.first)
         if @props.student_name.last != next.student_name.last
             @setState(edited_last_name : next.student_name.last)
+        if @props.student.get('email_address') != next.student.get('email_address')
+            @setState(edited_email_address : next.student.get('email_address'))
 
     getInitialState: ->
         confirm_delete    : false
         editing_student   : false
         edited_first_name : @props.student_name.first
         edited_last_name  : @props.student_name.last
+        edited_email_address      : @props.student.get('email_address')
 
     on_key_down: (e) ->
         switch e.keyCode
             when 13
-                @save_student_name()
+                @save_student_changes()
             when 27
                 @cancel_student_edit()
 
@@ -526,7 +529,7 @@ Student = rclass
                         </Tip>
                     </Button>
                 </ButtonGroup>
-                {@render_edit_name() if @props.student.get('account_id')}
+                {@render_edit_student() if @props.student.get('account_id')}
             </ButtonToolbar>
         else
             <Tip placement='right'
@@ -537,11 +540,16 @@ Student = rclass
                 </Button>
             </Tip>
 
-    render_edit_name: ->
+    student_changed: ->
+        @props.student_name.first != @state.edited_first_name or
+            @props.student_name.last != @state.edited_last_name or
+            @props.student.get('email_address') != @state.edited_email_address
+
+    render_edit_student: ->
         if @state.editing_student
-            disable_save = @props.student_name.first == @state.edited_first_name and @props.student_name.last == @state.edited_last_name
+            disable_save = not @student_changed()
             <ButtonGroup>
-                <Button onClick={@save_student_name} bsStyle='success' disabled={disable_save}>
+                <Button onClick={@save_student_changes} bsStyle='success' disabled={disable_save}>
                     <Icon name='save'/> Save
                 </Button>
                 <Button onClick={@cancel_student_edit} >
@@ -556,8 +564,12 @@ Student = rclass
     cancel_student_edit: ->
         @setState(@getInitialState())
 
-    save_student_name: ->
-        @actions(@props.name).set_internal_student_name(@props.student, @state.edited_first_name, @state.edited_last_name)
+    save_student_changes: ->
+        @actions(@props.name).set_internal_student_info @props.student,
+            first_name    : @state.edited_first_name
+            last_name     : @state.edited_last_name
+            email_address : @state.edited_email_address
+
         @setState(editing_student:false)
 
     show_edit_name_dialogue: ->
@@ -723,6 +735,20 @@ Student = rclass
                             onClick    = {(e) => e.stopPropagation(); e.preventDefault()}
                             onChange   = {(e) => @setState(edited_last_name : e.target.value)}
                             onKeyDown  = {@on_key_down}
+                        />
+                    </FormGroup>
+                </Col>
+            </Row>
+            <Row>
+                <Col md=12>
+                    Email Address
+                    <FormGroup>
+                        <FormControl
+                            type      = 'text'
+                            value     = {@state.edited_email_address}
+                            onClick   = {(e) => e.stopPropagation(); e.preventDefault()}
+                            onChange  = {(e) => @setState(edited_email_address : e.target.value)}
+                            onKeyDown = {@on_key_down}
                         />
                     </FormGroup>
                 </Col>


### PR DESCRIPTION
Addresses #1669.
![edit_email](https://cloud.githubusercontent.com/assets/618575/24978479/b1e2a61e-1f85-11e7-96ed-4a7703869584.png)
Works just like first and last name forms. 
- `Tab` to next input works. 
- `Enter` on any field submits the form. 
- `Esc` on any input cancels all changes. 
- The save button is disabled unless changes have been made

Does **not** display the student's prior or actual email. 