### PR TITLE
Fix file drop notification

### DIFF
--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -152,11 +152,12 @@ Page = rclass
             console.log "react desktop_app.drop", e
         e.preventDefault()
         e.stopPropagation()
-        {alert_message} = require('./alerts')
-        alert_message
-            type     : 'info'
-            title    : 'File drop disabled'
-            message  : 'To upload a file, drop it onto the files listing or the "Drop files to upload" area in the +New tab.'
+        if e.dataTransfer.files.length > 0
+            {alert_message} = require('./alerts')
+            alert_message
+                type     : 'info'
+                title    : 'File Drop Rejected'
+                message  : 'To upload a file, drop it onto the files listing'
 
     render: ->
         style =

--- a/src/smc-webapp/desktop_app.cjsx
+++ b/src/smc-webapp/desktop_app.cjsx
@@ -144,7 +144,6 @@ Page = rclass
         </Nav>
 
     # register a default drag and drop handler, that prevents accidental file drops
-    # therefore, dropping files only works when done right above the dedicated dropzone
     # TEST: make sure that usual drag'n'drop activities like rearranging tabs and reordering tasks work
     drop: (e) ->
         if DEBUG
@@ -157,7 +156,7 @@ Page = rclass
             alert_message
                 type     : 'info'
                 title    : 'File Drop Rejected'
-                message  : 'To upload a file, drop it onto the files listing'
+                message  : 'To upload a file, drop it onto the files listing or the "Drop files to upload" area in the +New tab.'
 
     render: ->
         style =

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -24,7 +24,7 @@
  ButtonToolbar, Popover, OverlayTrigger, SplitButton, MenuItem, Alert, Checkbox} =  require('react-bootstrap')
 misc = require('smc-util/misc')
 {ActivityDisplay, DeletedProjectWarning, DirectoryInput, Icon, Loading, ProjectState, SAGE_LOGO_COLOR
- SearchInput, SMC_Dropzone, TimeAgo, ErrorDisplay, Space, Tip, LoginLink, Footer, CourseProjectExtraHelp} = require('./r_misc')
+ SearchInput, SMC_Dropwrapper, TimeAgo, ErrorDisplay, Space, Tip, LoginLink, Footer, CourseProjectExtraHelp} = require('./r_misc')
 {FileTypeSelector, NewFileButton} = require('./project_new')
 
 {BillingPageLink, BillingPageForCourseRedux, PayCourseFee}     = require('./billing')
@@ -2073,7 +2073,7 @@ exports.ProjectFiles = rclass ({name}) ->
                 </Button>
             </div>
         else if listing?
-            <SMC_Dropzone
+            <SMC_Dropwrapper
                 project_id     = {@props.project_id}
                 dest_path      = {@props.current_path}
                 event_handlers = {complete : => @props.actions.fetch_directory_listing()}
@@ -2096,7 +2096,7 @@ exports.ProjectFiles = rclass ({name}) ->
                     shift_is_down       = {@state.shift_is_down}
                     event_handlers
                 />
-            </SMC_Dropzone>
+            </SMC_Dropwrapper>
         else
             @update_current_listing()
             <div style={fontSize:'40px', textAlign:'center', color:'#999999'} >

--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -23,8 +23,8 @@
 {Col, Row, ButtonToolbar, ButtonGroup, MenuItem, Button, Well, FormControl, FormGroup
  ButtonToolbar, Popover, OverlayTrigger, SplitButton, MenuItem, Alert, Checkbox} =  require('react-bootstrap')
 misc = require('smc-util/misc')
-{ActivityDisplay, AllowFileDropping, DeletedProjectWarning, DirectoryInput, Icon, Loading, ProjectState, SAGE_LOGO_COLOR
- SearchInput, TimeAgo, ErrorDisplay, Space, Tip, LoginLink, Footer, CourseProjectExtraHelp} = require('./r_misc')
+{ActivityDisplay, DeletedProjectWarning, DirectoryInput, Icon, Loading, ProjectState, SAGE_LOGO_COLOR
+ SearchInput, SMC_Dropzone, TimeAgo, ErrorDisplay, Space, Tip, LoginLink, Footer, CourseProjectExtraHelp} = require('./r_misc')
 {FileTypeSelector, NewFileButton} = require('./project_new')
 
 {BillingPageLink, BillingPageForCourseRedux, PayCourseFee}     = require('./billing')
@@ -84,7 +84,6 @@ PathSegmentLink = rclass
 
     handle_click: ->
         @props.actions.open_directory(@props.path)
-        @props.actions.show_upload(false)
 
     render_link: ->
         <a style={@styles} onClick={@handle_click}>{@props.display}</a>
@@ -535,7 +534,7 @@ pager_range = (page_size, page_number) ->
     start_index = page_size*page_number
     return {start_index: start_index, end_index: start_index + page_size}
 
-FileListing = AllowFileDropping rclass
+FileListing = rclass
     displayName: 'ProjectFiles-FileListing'
 
     propTypes:
@@ -1849,7 +1848,6 @@ exports.ProjectFiles = rclass ({name}) ->
             selected_file_index : rtypes.number
             file_creation_error : rtypes.string
             displayed_listing   : rtypes.object
-            show_upload         : rtypes.bool
             new_name            : rtypes.string
 
     propTypes :
@@ -1968,7 +1966,6 @@ exports.ProjectFiles = rclass ({name}) ->
             actions      = {@props.actions} />
 
     render_new_file : ->
-        style = if @props.show_upload then 'primary' else 'default'
         <Col sm=3>
             <ProjectFilesNew
                 file_search   = {@props.file_search}
@@ -1977,9 +1974,7 @@ exports.ProjectFiles = rclass ({name}) ->
                 create_file   = {@create_file}
                 create_folder = {@create_folder} />
             <Button
-                bsStyle = {style}
-                onClick = {@props.actions.toggle_upload}
-                active  = {@props.show_upload}
+                className = "upload-button"
                 >
                 <Icon name='upload' /> Upload
             </Button>
@@ -2078,23 +2073,30 @@ exports.ProjectFiles = rclass ({name}) ->
                 </Button>
             </div>
         else if listing?
-            <FileListing
-                listing             = {listing}
-                page_size           = {@file_listing_page_size()}
-                page_number         = {@props.page_number}
-                file_map            = {file_map}
-                file_search         = {@props.file_search}
-                checked_files       = {@props.checked_files}
-                current_path        = {@props.current_path}
-                public_view         = {public_view}
-                actions             = {@props.actions}
-                create_file         = {@create_file}
-                create_folder       = {@create_folder}
-                selected_file_index = {@props.selected_file_index}
-                project_id          = {@props.project_id}
-                show_upload         = {@props.show_upload}
-                shift_is_down       = {@state.shift_is_down}
-            />
+            <SMC_Dropzone
+                project_id     = {@props.project_id}
+                dest_path      = {@props.current_path}
+                event_handlers = {complete : => @props.actions.fetch_directory_listing()}
+                config         = {clickable : ".upload-button"}
+            >
+                <FileListing
+                    listing             = {listing}
+                    page_size           = {@file_listing_page_size()}
+                    page_number         = {@props.page_number}
+                    file_map            = {file_map}
+                    file_search         = {@props.file_search}
+                    checked_files       = {@props.checked_files}
+                    current_path        = {@props.current_path}
+                    public_view         = {public_view}
+                    actions             = {@props.actions}
+                    create_file         = {@create_file}
+                    create_folder       = {@create_folder}
+                    selected_file_index = {@props.selected_file_index}
+                    project_id          = {@props.project_id}
+                    shift_is_down       = {@state.shift_is_down}
+                    event_handlers
+                />
+            </SMC_Dropzone>
         else
             @update_current_listing()
             <div style={fontSize:'40px', textAlign:'center', color:'#999999'} >

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -364,6 +364,33 @@ exports.unmount = (dom_node) ->
     #console.log("unmount project_new")
     ReactDOM.unmountComponentAtNode(dom_node)
 
+FileUpload = rclass ({name}) ->
+    displayName : 'ProjectNew-FileUpload'
+
+    reduxProps :
+        "#{name}" :
+            current_path : rtypes.string
+
+    propTypes :
+        project_id : rtypes.string.isRequired
+
+    mixins : [ImmutablePureRenderMixin]
+
+    render: ->
+        {SMC_Dropzone} = require('./r_misc')
+
+        <Row>
+            <Col sm=3>
+                <h4><Icon name='cloud-upload' /> Upload files from your computer</h4>
+            </Col>
+            <Col sm=8>
+                <SMC_Dropzone
+                    dropzone_handler     = {{}}
+                    project_id           = @props.project_id
+                    current_path         = @props.current_path />
+            </Col>
+        </Row>
+
 exports.ProjectNew = rclass ({name}) ->
     propTypes :
         project_id : rtypes.string
@@ -372,4 +399,6 @@ exports.ProjectNew = rclass ({name}) ->
     render: ->
         <div style={padding:'15px'}>
             <ProjectNewForm project_id={@props.project_id} name={@props.name} actions={@actions(name)} />
+            <hr />
+            <FileUpload project_id={@props.project_id} name={@props.name} />
         </div>

--- a/src/smc-webapp/project_new.cjsx
+++ b/src/smc-webapp/project_new.cjsx
@@ -364,33 +364,6 @@ exports.unmount = (dom_node) ->
     #console.log("unmount project_new")
     ReactDOM.unmountComponentAtNode(dom_node)
 
-FileUpload = rclass ({name}) ->
-    displayName : 'ProjectNew-FileUpload'
-
-    reduxProps :
-        "#{name}" :
-            current_path : rtypes.string
-
-    propTypes :
-        project_id : rtypes.string.isRequired
-
-    mixins : [ImmutablePureRenderMixin]
-
-    render: ->
-        {SMC_Dropzone} = require('./r_misc')
-
-        <Row>
-            <Col sm=3>
-                <h4><Icon name='cloud-upload' /> Upload files from your computer</h4>
-            </Col>
-            <Col sm=8>
-                <SMC_Dropzone
-                    dropzone_handler     = {{}}
-                    project_id           = @props.project_id
-                    current_path         = @props.current_path />
-            </Col>
-        </Row>
-
 exports.ProjectNew = rclass ({name}) ->
     propTypes :
         project_id : rtypes.string
@@ -399,6 +372,4 @@ exports.ProjectNew = rclass ({name}) ->
     render: ->
         <div style={padding:'15px'}>
             <ProjectNewForm project_id={@props.project_id} name={@props.name} actions={@actions(name)} />
-            <hr />
-            <FileUpload project_id={@props.project_id} name={@props.name} />
         </div>

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1653,10 +1653,55 @@ Drag'n'Drop dropzone area
 ###
 ReactDOMServer = require('react-dom/server')   # for dropzone below
 Dropzone       = require('dropzone')
+DropComponent  = require('react-dropzone-component')
 Dropzone.autoDiscover = false
 
-# config is a placeholder for any configuration details that can't be passed as a prop to the returned component
 exports.SMC_Dropzone = rclass
+    displayName: 'SMC_Dropzone'
+
+    propTypes:
+        project_id           : rtypes.string.isRequired
+        current_path         : rtypes.string.isRequired
+        dropzone_handler     : rtypes.object.isRequired
+
+    dropzone_template : ->
+        <div className='dz-preview dz-file-preview'>
+            <div className='dz-details'>
+                <div className='dz-filename'><span data-dz-name></span></div>
+                <img data-dz-thumbnail />
+            </div>
+            <div className='dz-progress'><span className='dz-upload' data-dz-uploadprogress></span></div>
+            <div className='dz-success-mark'><span><Icon name='check'></span></div>
+            <div className='dz-error-mark'><span><Icon name='times'></span></div>
+            <div className='dz-error-message'><span data-dz-errormessage></span></div>
+        </div>
+
+    postUrl : ->
+        dest_dir = misc.encode_path(@props.current_path)
+        postUrl  = window.smc_base_url + "/upload?project_id=#{@props.project_id}&dest_dir=#{dest_dir}"
+        return postUrl
+
+    render: ->
+        <div>
+            {<div className='close-button pull-right'>
+                <span
+                    onClick={@props.close_button_onclick}
+                    className='close-button-x'
+                    style={cursor: 'pointer', fontSize: '18px', color:'gray'}><i className="fa fa-times"></i></span>
+            </div> if @props.close_button_onclick?}
+            <Tip icon='file' title='Drag and drop files' placement='top'
+                tip='Drag and drop files from your computer into the box below to upload them into your project.  You can upload individual files that are up to 30MB in size.'>
+                <h4 style={color:"#666"}>Drag and drop files (Currently, each file must be under 30MB; for bigger files, use SSH as explained in project settings.)</h4>
+            </Tip>
+            <div style={border: '2px solid #ccc', boxShadow: '4px 4px 2px #bbb', borderRadius: '5px', padding: 0, margin: '10px'}>
+                <DropComponent
+                    config        = {postUrl: @postUrl()}
+                    eventHandlers = {@props.dropzone_handler}
+                    djsConfig     = {previewTemplate: ReactDOMServer.renderToStaticMarkup(@dropzone_template())} />
+            </div>
+        </div>
+
+exports.SMC_Dropwrapper = rclass
         displayName: 'dropzone-wrapper'
 
         propTypes:

--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1778,6 +1778,7 @@ exports.SMC_Dropwrapper = rclass
         close_preview: ->
             @props.on_close?()
             @dropzone?.removeAllFiles()
+            @setState(files : [])
 
         render_preview: ->
             if not @props.show_upload and @state.files.length == 0
@@ -1824,7 +1825,6 @@ exports.SMC_Dropwrapper = rclass
             return unless @dropzone?
 
             for name, handlers of @props.event_handlers
-                console.log "registering", name
                 # Check if there's an array of event handlers
                 if Object.prototype.toString.call(handlers) == '[object Array]'
                     for handler in handlers
@@ -1844,16 +1844,6 @@ exports.SMC_Dropwrapper = rclass
                     files = @state.files
                     files.push(file)
                     @setState(files : files)
-
-            @dropzone.on 'removedfile', (file) =>
-                files = @state.files
-                return unless file and files
-
-                for item, i in files
-                    if item.name == file.name and item.size == file.size
-                        files.splice(i, 1)
-
-                @setState(files : files)
 
         # Removes ALL listeners and Destroys dropzone.
         # see https://github.com/enyo/dropzone/issues/1175


### PR DESCRIPTION
Fixes #1478, #1237. 

Provides stepping stone to #1238 and #935 by creating an initial wrapper component that directly uses Dropzone.js. It is basically a slightly altered coffeescript rewrite of `react-dropzone-component` that is still used on the +New page.

List of other changes below
- Dragging non-files (like icon links) across the page now does nothing instead of giving the user an error.
- Dragging a file onto a non-drop-enabled area now says "File Rejected" instead of "File Drop Disabled"
- Dragging a file onto the files area now works automatically without having to hit some specific dropzone that gets rendered.
  - Also works on a directory with no files.
- Clicking Upload on the Files page now opens a file upload dialogue.
- Upload status on the Files page is now only as big as it needs to be
![upload status](https://cloud.githubusercontent.com/assets/618575/24979539/6b8b76b0-1f89-11e7-8fef-f2ee30745d1e.png)

Tested:
- Clicking X on files page uploader clears the status area
- Dragging multiple files works
- Uploader form results in upload status identical to dragging onto files
- Dropping non-files anywhere does nothing unless defined elsewhere (ie, text onto a text field)
- Dropping files only does some
- Dropzone on the +New Page stays the same