### PR TITLE
sagews: fixing shlex by using ushlex

### DIFF
--- a/src/smc_sagews/setup.py
+++ b/src/smc_sagews/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email     = 'office@sagemath.com',
     license          = 'GPLv3+',
     packages         = ['smc_sagews'],
-    install_requires = ['markdown2', 'ansi2html'],
+    install_requires = ['markdown2', 'ansi2html', 'ushlex'],
     zip_safe        = False,
     classifiers     = [
         'License :: OSI Approved :: GPLv3',

--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -962,11 +962,11 @@ class Salvus(object):
             try:
                 b = block.rstrip()
                 # get rid of comments at the end of the line -- issue #1835
-                #from shlex import shlex
-                #s = shlex(b)
-                #s.commenters = '#'
-                #s.quotes = '''"\''''
-                #b = ''.join(s)
+                from ushlex import shlex
+                s = shlex(b)
+                s.commenters = '#'
+                s.quotes = '"\''
+                b = ''.join(s)
                 # e.g. now a line like 'x = test?   # bar' becomes 'x=test?'
                 if b.endswith('??'):
                     p = sage_parsing.introspect(b,


### PR DESCRIPTION
This fixes https://github.com/sagemathinc/smc/pull/1849 by using `ushlex`.

I made https://github.com/sagemathinc/smc/issues/1859 without really knowing how to actually test this. In particular I'm wondering if there are any utf8 strings in that test suite. 