### PR TITLE
Only sort tabs when dragging a sortable item

### DIFF
--- a/src/smc-webapp/project_page.cjsx
+++ b/src/smc-webapp/project_page.cjsx
@@ -507,6 +507,7 @@ exports.ProjectPage = ProjectPage = rclass ({name}) ->
                     distance             = {3 if not IS_MOBILE}
                     bsStyle              = "pills"
                     style                = {display:'flex', overflow:'hidden', flex: 1}
+                    shouldCancelStart    = {(e)=>e.target.getAttribute('class')?.includes('smc-file-tabs')}
                 >
                     {@file_tabs()}
                 </SortableNav>

--- a/src/smc-webapp/projects_nav.cjsx
+++ b/src/smc-webapp/projects_nav.cjsx
@@ -176,13 +176,16 @@ FullProjectsNav = rclass
             width       : '100%'
             display     : 'flex'
 
-        <SortableNav style={display:'flex', flex:'1', overflow: 'hidden', height:'41px', margin:'0'}
-            helperClass={'smc-project-tab-floating'}
-            onSortEnd={@on_sort_end}
-            axis={'x'}
-            lockAxis={'x'}
-            lockToContainerEdges={true}
-            distance={3 if not isMobile.tablet()}
+        <SortableNav
+            className            = "smc-project-tab-sorter"
+            style                = {display:'flex', flex:'1', overflow: 'hidden', height:'41px', margin:'0'}
+            helperClass          = {'smc-project-tab-floating'}
+            onSortEnd            = {@on_sort_end}
+            axis                 = {'x'}
+            lockAxis             = {'x'}
+            lockToContainerEdges = {true}
+            distance             = {3 if not isMobile.tablet()}
+            shouldCancelStart    = {(e)=>e.target.getAttribute('class')?.includes('smc-project-tab-sorter')}
         >
             {@project_tabs()}
         </SortableNav>


### PR DESCRIPTION
Fixes case for #1738 for which I could reproduce.

Reproduce case: Drag on the space near a file or project tab and you get the error. 

Fix: Dragging on that space no longer triggers react-sortable.