### PR TITLE
add TestUnicode and skip TestLex

### DIFF
--- a/src/smc_sagews/smc_sagews/tests/test_sagews.py
+++ b/src/smc_sagews/smc_sagews/tests/test_sagews.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # test_sagews.py
 # basic tests of sage worksheet using TCP protocol with sage_server
 import socket
@@ -7,6 +8,9 @@ import re
 
 from textwrap import dedent
 
+import pytest
+
+@pytest.mark.skip(reason="waiting until #1835 is fixed")
 class TestLex:
     def test_lex_1(self, execdoc):
         execdoc("x = random? # bar")
@@ -16,6 +20,55 @@ class TestLex:
         exec2("x = 1 # plot?\nx","1\n")
     def test_lex_4(self, exec2):
         exec2('x="random?" # plot?\nx',"'random?'\n")
+
+class TestUnicode:
+    r"""
+    To pass unicode in a simulated input cell, quote it.
+    That will send the same message to sage_server
+    as a real input cell without the outer quotes.
+    """
+    def test_unicode_1(self, exec2):
+        r"""
+        test for cell with input u"äöüß"
+        """
+        ustr = 'u"äöüß"'
+        uout = ustr[2:-1].decode('utf8').__repr__().decode('utf8')
+        exec2(ustr, uout)
+    def test_unicode_2(self, exec2):
+        r"""
+        Test for cell with input u"ááá".
+        Input u"ááá" in an actual cell causes latin1 encoding to appear
+        enclosed by u"...", inside a unicode string in the message to sage_server.
+        (So there are two u's in the displayed message in the log.)
+        Code part of logged input message to sage_server:
+          u'code': u'u"\xe1\xe1\xe1"\n'
+        Stdout part of logged output message from sage_server:
+          "stdout": "u\'\\\\xe1\\\\xe1\\\\xe1\'\\n"
+        """
+        ustr = 'u"ááá"'
+        # same as below: uout = u"u'\\xe1\\xe1\\xe1'\n"
+        uout = ustr[2:-1].decode('utf8').__repr__().decode('utf8')
+        exec2(ustr, uout)
+    def test_unicode_3(self, exec2):
+        r"""
+        Test for cell with input "ááá".
+        Input "ááá" in an actual cell causes utf8 encoding to appear
+        inside a unicode string in the message to sage_server.
+        Code part of logged input message to sage_server:
+          u'code': u'"\xe1\xe1\xe1"\n'
+        Stdout part of logged output message from sage_server:
+          "stdout": "\'\\\\xc3\\\\xa1\\\\xc3\\\\xa1\\\\xc3\\\\xa1\'\\n"
+        """
+        ustr = '"ááá"'
+        uout = ustr[1:-1].decode('utf8').encode('utf8').__repr__().decode('utf8')
+        exec2(ustr, uout)
+    def test_unicode_4(self, exec2):
+        r"""
+        test for cell with input "öäß"
+        """
+        ustr = '"öäß"'
+        uout = ustr[1:-1].decode('utf8').encode('utf8').__repr__().decode('utf8')
+        exec2(ustr, uout)
 
 class TestDecorators:
     def test_simple_dec(self, exec2):


### PR DESCRIPTION
ref: #1859 

No changes to production code.
Adds 4 tests, class TestUnicode.
To test, check out the patch and do (assuming your smc repo is at ~/smc):
```
cd ~/smc/src/smc_sagews/smc_sagews/tests
python -m pytest test_sagews.py::TestUnicode
```

Note: Other tests in src/smc_sagews/smc_sagews/tests are broken. Out of scope for this PR.