### PR TITLE
webapp/files/create new file dropdown: instead of hardcoding a width, tell it to not do any linebreaks

### DIFF
--- a/src/smc-webapp/project_files.cjsx
+++ b/src/smc-webapp/project_files.cjsx
@@ -1803,7 +1803,7 @@ ProjectFilesNew = rclass
 
     render: ->
         # This div prevents the split button from line-breaking when the page is small
-        <div style={width:'111px', display: 'inline-block', marginRight: '20px' }>
+        <div style={whiteSpace: 'nowrap', display: 'inline-block', marginRight: '20px' }>
             <SplitButton id='new_file_dropdown' title={@file_dropdown_icon()} onClick={@on_create_button_clicked} >
                 {(@file_dropdown_item(i, ext) for i, ext of @new_file_button_types)}
                 <MenuItem divider />


### PR DESCRIPTION
see issue #1885

with that change it looks ok for me in chrome, someone should give safari a try, too.

also, I've no idea what did trigger this, hence that's just a patch to fix this in a sane way without knowing a deeper cause. maybe it just waited to be triggered ...