### PR TITLE
webapp/video-chat: workaround for #1899

### DIFF
--- a/src/smc-webapp/video-chat.cjsx
+++ b/src/smc-webapp/video-chat.cjsx
@@ -33,19 +33,20 @@ VIDEO_UPDATE_INTERVAL_MS = 30*1000
 VIDEO_CHAT_LIMIT         = 8       # imposed by free appear.in plan
 
 # The pop-up window for video chat
-video_window = (title, url) ->
-    w = window.open("", null, "height=640,width=800")
-    w.document.write """
-<html>
-    <head>
-        <title>#{title}</title>
-    </head>
-    <body style='margin: 0px'>
-        <iframe src='#{url}' width='100%' height='100%' frameborder=0>
-        </iframe>
-    </body>
-</html>
-"""
+video_window = (title, url, cb_closed) ->
+    w = window.open(url, null, "location=yes,resizable=yes,height=640,width=800")
+    # disabled, see https://github.com/sagemathinc/smc/issues/1899
+    #w.document.write """
+    #<html>
+    #    <head>
+    #        <title>#{title}</title>
+    #    </head>
+    #    <body style='margin: 0px'>
+    #        <iframe src='#{url}' width='100%' height='100%' frameborder=0>
+    #        </iframe>
+    #    </body>
+    #</html>
+    #"""
     return w
 
 video_windows = {}
@@ -103,8 +104,15 @@ class VideoChat
         url   = "https://appear.in/#{room_id}"
         w     = video_window(title, url)
         video_windows[room_id] = w
-        w.addEventListener "unload", =>
-            @close_video_chat_window()
+        # disabled -- see https://github.com/sagemathinc/smc/issues/1899
+        #w.addEventListener "unload", =>
+        #    @close_video_chat_window()
+        # workaround for https://github.com/sagemathinc/smc/issues/1899
+        poll_window = window.setInterval( =>
+            if w.closed != false # != is required for compatibility with Opera
+                window.clearInterval(poll_window)
+                @close_video_chat_window()
+        , 1000)
 
     # User wants to close the video chat window, but not via just clicking the
     # close button on the popup window


### PR DESCRIPTION
see #1899

test: (i.e. what I checked in chrome and firefox) open video chat, indicator is "1", close the window, ~1 sec later the indicator is "0".

process: testing some approaches, in the end http://stackoverflow.com/questions/3291712/is-it-possible-to-open-a-popup-with-javascript-and-then-detect-when-the-user-clo was most helpful.

time: 25 min