### PR TITLE
jupyter2: tablewidth auto, otherwise it looks ridiculous for some R dataframes

### DIFF
--- a/src/smc-webapp/jupyter/_jupyter.sass
+++ b/src/smc-webapp/jupyter/_jupyter.sass
@@ -6,6 +6,9 @@
     //margin-left  : auto
     //margin-right : auto
 
+  table.table
+    width        : auto
+
 .cocalc-jupyter-anchor-link
   visibility : hidden
 


### PR DESCRIPTION
e.g. `data.frame(list(x=c(1,2,4), y = c(9,8,2)))`