### PR TITLE
issue #1941 skip non-jsonable file names

### DIFF
--- a/src/smc_pyutil/smc_pyutil/smc_compute.py
+++ b/src/smc_pyutil/smc_pyutil/smc_compute.py
@@ -626,8 +626,9 @@ class Project(object):
         except:
             # Throw away filenames that can't be json'd, since they can't be JSON'd below,
             # which would totally lock user out of their listings.
+            ld0 = listdir[:]
             listdir = []
-            for x in os.listdir('.'):
+            for x in ld0:
                 try:
                     json.dumps(x)
                     listdir.append(x)


### PR DESCRIPTION
ref: #1941 

Tested by creating a directory with bad file names, checking that directory contents did not list correctly with smc_compute.py's `Project().directory_listing()`, then changing code and getting a correct list (with only the JSON-able filenames). Test code is in this (non-public) notebook: 
https://cocalc.com/projects/ccd4d4a4-29a8-4c39-85c2-a630cb1e9b6c/files/TEST_SAGEWS/issue-1941.ipynb

