### PR TITLE
move annoying attach/reload message from cell output to log

### DIFF
--- a/src/smc_sagews/smc_sagews/sage_server.py
+++ b/src/smc_sagews/smc_sagews/sage_server.py
@@ -66,7 +66,7 @@ def reload_attached_files_if_mod_smc():
     for filename, mtime in modified_file_iterator():
         basename = os.path.basename(filename)
         timestr = time.strftime('%T', mtime)
-        print('### reloading attached file {0} modified at {1} ###'.format(basename, timestr))
+        log('reloading attached file {0} modified at {1}'.format(basename, timestr))
         from sage_salvus import load
         load(filename)
 


### PR DESCRIPTION
See #1948 

Verified that pytests for %attach still work.