### PR TITLE
Mirror student list sort inside assignments

### DIFF
--- a/src/smc-webapp/course/assignments_panel.cjsx
+++ b/src/smc-webapp/course/assignments_panel.cjsx
@@ -22,6 +22,7 @@ exports.AssignmentsPanel = rclass ({name}) ->
         "#{name}":
             expanded_assignments   : rtypes.immutable.Set
             active_assignment_sort : rtypes.object
+            active_student_sort    : rtypes.immutable.Map
 
     propTypes :
         name            : rtypes.string.isRequired
@@ -81,11 +82,17 @@ exports.AssignmentsPanel = rclass ({name}) ->
 
     render_assignments: (assignments) ->
         for x,i in assignments
-            <Assignment background={if i%2==0 then "#eee"}  key={x.assignment_id} assignment={@props.all_assignments.get(x.assignment_id)}
-                    project_id={@props.project_id}  redux={@props.redux}
-                    students={@props.students} user_map={@props.user_map}
-                    name={@props.name}
-                    is_expanded={@props.expanded_assignments.has(x.assignment_id)}
+            <Assignment
+                    key                 = {x.assignment_id}
+                    assignment          = {@props.all_assignments.get(x.assignment_id)}
+                    background          = {if i%2==0 then "#eee"}
+                    project_id          = {@props.project_id}
+                    redux               = {@props.redux}
+                    students            = {@props.students}
+                    user_map            = {@props.user_map}
+                    name                = {@props.name}
+                    is_expanded         = {@props.expanded_assignments.has(x.assignment_id)}
+                    active_student_sort = {@props.active_student_sort}
                     />
 
     render_show_deleted: (num_deleted) ->
@@ -152,17 +159,18 @@ Assignment = rclass
     displayName : "CourseEditor-Assignment"
 
     propTypes :
-        name       : rtypes.string.isRequired
-        assignment : rtypes.object.isRequired
-        project_id : rtypes.string.isRequired
-        redux      : rtypes.object.isRequired
-        students   : rtypes.object.isRequired
-        user_map   : rtypes.object.isRequired
-        background : rtypes.string
-        is_expanded : rtypes.bool
+        name                : rtypes.string.isRequired
+        assignment          : rtypes.object.isRequired
+        project_id          : rtypes.string.isRequired
+        redux               : rtypes.object.isRequired
+        students            : rtypes.object.isRequired
+        user_map            : rtypes.object.isRequired
+        background          : rtypes.string
+        is_expanded         : rtypes.bool
+        active_student_sort : rtypes.immutable.Map
 
     shouldComponentUpdate: (nextProps, nextState) ->
-        return @state != nextState or @props.assignment != nextProps.assignment or @props.students != nextProps.students or @props.user_map != nextProps.user_map or @props.background != nextProps.background or @props.is_expanded != nextProps.is_expanded
+        return @state != nextState or @props.assignment != nextProps.assignment or @props.students != nextProps.students or @props.user_map != nextProps.user_map or @props.background != nextProps.background or @props.is_expanded != nextProps.is_expanded or @props.active_student_sort != nextProps.active_student_sort
 
     getInitialState: ->
         confirm_delete : false
@@ -292,9 +300,14 @@ Assignment = rclass
         <Row key='more'>
             <Col sm=12>
                 <Panel header={@render_more_header()}>
-                    <StudentListForAssignment redux={@props.redux} name={@props.name}
-                        assignment={@props.assignment} students={@props.students}
-                        user_map={@props.user_map} />
+                    <StudentListForAssignment
+                        redux               = {@props.redux}
+                        name                = {@props.name}
+                        assignment          = {@props.assignment}
+                        students            = {@props.students}
+                        user_map            = {@props.user_map}
+                        active_student_sort = {@props.active_student_sort}
+                        />
                     {@render_note()}
                 </Panel>
             </Col>
@@ -704,12 +717,13 @@ StudentListForAssignment = rclass
     displayName : "CourseEditor-StudentListForAssignment"
 
     propTypes :
-        name       : rtypes.string.isRequired
-        redux      : rtypes.object.isRequired
-        assignment : rtypes.object.isRequired
-        students   : rtypes.object.isRequired
-        user_map   : rtypes.object.isRequired
-        background : rtypes.string
+        name                : rtypes.string.isRequired
+        redux               : rtypes.object.isRequired
+        assignment          : rtypes.object.isRequired
+        students            : rtypes.object.isRequired
+        user_map            : rtypes.object.isRequired
+        background          : rtypes.string
+        active_student_sort : rtypes.immutable.Map
 
     render_student_info: (student_id) ->
         store = @props.redux.getStore(@props.name)
@@ -723,21 +737,12 @@ StudentListForAssignment = rclass
               info    = {store.student_assignment_info(student_id, @props.assignment)} />
 
     render_students: ->
-        v = course_funcs.immutable_to_list(@props.students, 'student_id')
+        v = course_funcs.parse_students(@props.students, @props.user_map, @props.redux)
         # fill in names, for use in sorting and searching (TODO: caching)
         v = (x for x in v when not x.deleted)
-        for x in v
-            user = @props.user_map.get(x.account_id)
-            if user?
-                x.first_name = user.get('first_name')
-                x.last_name  = user.get('last_name')
-                x.name = x.first_name + ' ' + x.last_name
-                x.sort = (x.last_name + ' ' + x.first_name).toLowerCase()
-            else if x.email_address?
-                x.name = x.sort = x.email_address.toLowerCase()
-
-        v.sort (a,b) ->
-            return misc.cmp(a.sort, b.sort)
+        v.sort(course_funcs.pick_student_sorter(@props.active_student_sort.toJS()))
+        if @props.active_student_sort.get('is_descending')
+            v.reverse()
 
         for x in v
             @render_student_info(x.student_id)

--- a/src/smc-webapp/course/main.cjsx
+++ b/src/smc-webapp/course/main.cjsx
@@ -66,7 +66,7 @@ init_redux = (course_filename, redux, course_project_id) ->
         expanded_assignments   : immutable.Set() # Set of assignment id's (string) which should be expanded on render
         expanded_handouts      : immutable.Set() # Set of handout id's (string) which should be expanded on render
         active_student_sort    : {column_name : "last_name", is_descending : false}
-        active_assignment_sort : {column_name : "dir_name", is_descending : false}
+        active_assignment_sort : {column_name : "due_date", is_descending : false}
 
     actions = redux.createActions(the_redux_name, CourseActions)
     store = redux.createStore(the_redux_name, CourseStore, initial_store_state)

--- a/src/smc-webapp/course/students_panel.cjsx
+++ b/src/smc-webapp/course/students_panel.cjsx
@@ -11,6 +11,7 @@ misc = require('smc-util/misc')
 {User} = require('../users')
 {ErrorDisplay, Icon, MarkdownInput, SearchInput, Space, TimeAgo, Tip} = require('../r_misc')
 {StudentAssignmentInfo, StudentAssignmentInfoHeader} = require('./common')
+course_funcs = require('./course_funcs')
 
 selected_entry_style =
     border        : '1px solid #aaa'
@@ -242,20 +243,6 @@ exports.StudentsPanel = rclass ({name}) ->
             {@render_error()}
         </div>
 
-    sort_on_string_field: (field) ->
-        (a,b) -> misc.cmp(a[field].toLowerCase(), b[field].toLowerCase())
-
-    sort_on_numerical_field: (field) ->
-        (a,b) -> misc.cmp(a[field] * -1, b[field] * -1)
-
-    pick_sorter: (sort=@props.active_student_sort) ->
-        switch sort.column_name
-            when "email" then @sort_on_string_field("email_address")
-            when "first_name" then @sort_on_string_field("first_name")
-            when "last_name" then @sort_on_string_field("last_name")
-            when "last_active" then @sort_on_numerical_field("last_active")
-            when "hosting" then @sort_on_numerical_field("hosting")
-
     compute_student_list: ->
         # TODO: good place to cache something...
         # turn map of students into a list
@@ -270,27 +257,8 @@ exports.StudentsPanel = rclass ({name}) ->
         # deleted        : False
         # note           : "Is younger sister of Abby Florence (TA)"
 
-        v = immutable_to_list(@props.students, 'student_id')
-        # Fill in values
-        # TODO: Caching
-        for x in v
-            if x.account_id?
-                user = @props.user_map.get(x.account_id)
-                x.first_name ?= user?.get('first_name') ? ''
-                x.last_name  ?= user?.get('last_name') ? ''
-                if x.project_id?
-                    x.last_active = @props.redux.getStore('projects').get_last_active(x.project_id)?.get(x.account_id)?.getTime?()
-                    upgrades = @props.redux.getStore('projects').get_total_project_quotas(x.project_id)
-                    if upgrades?
-                        x.hosting = upgrades.member_host
-
-            x.first_name  ?= ""
-            x.last_name   ?= ""
-            x.last_active ?= 0
-            x.hosting ?= false
-            x.email_address ?= ""
-
-        v.sort(@pick_sorter())
+        v = course_funcs.parse_students(@props.students, @props.user_map, @props.redux)
+        v.sort(course_funcs.pick_student_sorter(@props.active_student_sort))
 
         if @props.active_student_sort.is_descending
             v.reverse()


### PR DESCRIPTION
Takes whatever sort order the student listing is in and applies it to the list of students for an assignment.
Sort of fixes #1635?

Also sets Due Date as default sorting for Assignments.

## Examples

**Last Name**
![sort by last name](https://cloud.githubusercontent.com/assets/618575/26018816/eeb306a8-3725-11e7-9e6e-2738c4067a25.png)
![assignment by last name](https://cloud.githubusercontent.com/assets/618575/26018815/eeb27bde-3725-11e7-8b89-d54b042c08e9.png)

**Email**
![sort by email](https://cloud.githubusercontent.com/assets/618575/26018814/eeb1de5e-3725-11e7-899f-738bdcb7c2ad.png)
![assignment email](https://cloud.githubusercontent.com/assets/618575/26018813/eeb037f2-3725-11e7-8bd8-181f7ebfeda0.png)

## Test
- Toggle open an assignment, change the student sort, then going back to the assignment should result in the new sort order displayed
- Due Date should be the default sort. 