### PR TITLE
allow absolute paths when clicking on log link

### DIFF
--- a/src/smc-webapp/r_misc.cjsx
+++ b/src/smc-webapp/r_misc.cjsx
@@ -1013,8 +1013,7 @@ exports.PathLink = rclass
 
     handle_click: (e) ->
         e.preventDefault()
-        path_head = 'files'
-        path_head += '/' if @props.path[0] != '/'
+        path_head = 'files/'
         @actions('projects').open_project
             project_id : @props.project_id
             target     : path_head + @props.path


### PR DESCRIPTION
Ref: #1939 

This simple change appears to fix the reported bug, but please review because
1. Other parts of SMC than clicking on log entries might use the code that is changed and depend on relative paths only.
1. There is one thing that is hard to test in smc-in-smc. If you have a file at an absolute path open in the browser and click refresh, smc-in-smc will try to open a file at the corresponding relative path, but it's not clear that regular smc will have the same problem.

More info on the second item. I think it relates to this line in salvus.coffee: https://github.com/sagemathinc/smc/blob/master/src/smc-webapp/salvus_client.coffee#L33
because:
1. Open an absolute path, e.g. `open /projects/sage/sage/README.md`
1. Copy the link from the browser location bar, e.g. https://cloud.sagemath.com/projects/.../files//projects/sage/sage/README.md where '...' is the project uuid.
1. Paste the link into location in a new browser tab and open. You will see the same file.
1. This does not work in smc-in-smc. If you open a file at an absolute path, copy the location, and try opening in a new tab, the double slash is removed and a file at the relative path is opened.