### PR TITLE
Add clearing ghost tabs on timeout

### DIFF
--- a/src/smc-webapp/project_store.coffee
+++ b/src/smc-webapp/project_store.coffee
@@ -151,6 +151,8 @@ class ProjectActions extends Actions
             @clear_ghost_file_tabs()
         else
             @add_a_ghost_file_tab()
+        window.clearTimeout(@last_close_timer)
+        @last_close_timer = window.setTimeout(@clear_ghost_file_tabs, 5000)
         @close_file(path)
 
     # Expects one of ['files', 'new', 'log', 'search', 'settings']


### PR DESCRIPTION
Simple fix for #1641.

Within 5 seconds, it will re-adjust your tabs unless you close the current tab.